### PR TITLE
RAM Disk robustness improvements. Fixes NG 3173

### DIFF
--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -2655,7 +2655,7 @@ function process_alias_urltable($name, $type, $url, $freq, $forceupdate=false, $
 
 			/* Remove existing archive and create an up to date archive if RAM disk is enabled. */
 			unlink_if_exists("{$g['cf_conf_path']}/RAM_Disk_Store/{$name}.txt.tgz");
-			if (isset($config['system']['use_mfs_tmpvar'])) {
+			if (isset($config['system']['use_mfs_tmpvar']) && !file_exists("/conf/ram_disks_failed")) {
 				mwexec("/usr/bin/tar -czf " . escapeshellarg("{$g['cf_conf_path']}/RAM_Disk_Store/{$name}.txt.tgz") . " -C / " . escapeshellarg($urltable_filename));
 			}
 

--- a/src/etc/inc/pkg-utils.inc
+++ b/src/etc/inc/pkg-utils.inc
@@ -104,7 +104,7 @@ function pkg_env($extra_env = array()) {
 		}
 	}
 
-	if (isset($config['system']['use_mfs_tmpvar'])) {
+	if (isset($config['system']['use_mfs_tmpvar']) && !file_exists("/conf/ram_disks_failed")) {
 		$pkg_env_vars['PKG_DBDIR'] = '/root/var/db/pkg';
 		$pkg_env_vars['PKG_CACHEDIR'] = '/root/var/cache/pkg';
 	}

--- a/src/etc/pfSense-rc
+++ b/src/etc/pfSense-rc
@@ -170,45 +170,37 @@ if [ -d "/conf" ]; then
 	fi
 fi
 
-USE_MFS_TMPVAR=$(/usr/local/sbin/read_xml_tag.sh boolean system/use_mfs_tmpvar)
+. /etc/rc.ramdisk_functions.sh
 
-unset MOVE_PKG_DATA
-# If use MFS var is disabled, move files back to place
-if [ "${USE_MFS_TMPVAR}" != "true" -a -f /root/var/db/pkg/local.sqlite ]; then
-	MOVE_PKG_DATA=1
-	rm -rf /var/db/pkg 2>/dev/null
-	rm -rf /var/cache/pkg 2>/dev/null
-	mv -f /root/var/db/pkg /var/db
-	mv -f /root/var/cache/pkg /var/cache
-# If use MFS var is enabled, move files to a safe place
-elif [ "${USE_MFS_TMPVAR}" = "true" -a -f /var/db/pkg/local.sqlite ]; then
-	MOVE_PKG_DATA=1
-	rm -rf /root/var/db/pkg 2>/dev/null
-	rm -rf /root/var/cache/pkg 2>/dev/null
-	/bin/mkdir -p /root/var/db /root/var/cache
-	mv -f /var/db/pkg /root/var/db
-	mv -f /var/cache/pkg /root/var/cache
+# Check if RAM disks are enabled, store for repeated use
+if ramdisk_check_enabled; then
+	USE_RAMDISK=true
 fi
 
-# Mount /var and /tmp on ZFS filesystems when it's necessary
-if [ -n "${USE_ZFS}" -a "${USE_MFS_TMPVAR}" = "true" ]; then
-	zfs list -H -o name,mountpoint |
-	    while read volume mountpoint; do
-		[ "${mountpoint}" != "/var" -a "${mountpoint}" != "/tmp" ] \
-			&& continue
+# Relocate pkgdb based on desired RAM disk settings
+ramdisk_relocate_pkgdb_all
 
-		/sbin/zfs umount ${volume}
-	done
+# Dismount /tmp and /var on ZFS if using RAM disks and they are separate volumes
+if [ -n "${USE_ZFS}" -a -n "${USE_RAMDISK}" ]; then
+	ramdisk_fixup_zfs
 fi
 
-if [ "${USE_MFS_TMPVAR}" = "true" ]; then
+# Attempt to create and mount RAM disks
+if [ -n "${USE_RAMDISK}" ]; then
 	/etc/rc.embedded
 fi
 
-if [ -n "${MOVE_PKG_DATA}" -o "${USE_MFS_TMPVAR}" = "true" ]; then
-	/bin/mkdir -p /var/db /var/cache
-	ln -sf ../../root/var/db/pkg /var/db/pkg
-	ln -sf ../../root/var/cache/pkg /var/cache/pkg
+# If RAM disks are active, make symlinks for pkg database
+if [ -n "${USE_RAMDISK}" -o -n "${MOVE_PKG_DATA}" ]; then
+	ramdisk_link_pkgdb
+fi
+
+# If activating RAM disks failed, then undo some of the above actions
+if [ -n "${USE_RAMDISK}" ] && ramdisk_failed; then
+	ramdisk_fixup_zfs mount
+	ramdisk_relocate_pkgdb disk
+else
+	ramdisk_reset_status
 fi
 
 # Read product_name from $g, defaults to pfSense
@@ -247,7 +239,7 @@ fi
 # Use php -n here because we are not ready to load extensions yet
 varrunpath=$(/usr/local/bin/php -n /usr/local/sbin/read_global_var varrun_path "/var/run")
 
-if [ "${USE_MFS_TMPVAR}" != "true" ]; then
+if ! ramdisk_is_active; then
 	/sbin/mdmfs -S -M -s 4m md $varrunpath
 fi
 

--- a/src/etc/pfSense-rc.shutdown
+++ b/src/etc/pfSense-rc.shutdown
@@ -44,16 +44,8 @@ export PATH
 # Remove temporary files on shutdown from /tmp/
 find -x /tmp/* -type f -exec rm -f {} \; >/dev/null 2>&1
 
-USE_MFS_TMPVAR=$(/usr/local/sbin/read_xml_tag.sh boolean system/use_mfs_tmpvar)
-DISK_NAME=`/bin/df /var/db/rrd | /usr/bin/tail -1 | /usr/bin/awk '{print $1;}'`
-DISK_TYPE=`/usr/bin/basename ${DISK_NAME} | /usr/bin/cut -c1-2`
-# If we are not on a full install, or if the full install wants RAM disks, or if the full install _was_ using RAM disks, but isn't for the next boot...
-if [ "${USE_MFS_TMPVAR}" = "true" ] || [ "${DISK_TYPE}" = "md" ]; then
-	/etc/rc.backup_aliastables.sh
-	/etc/rc.backup_rrd.sh
-	/etc/rc.backup_dhcpleases.sh
-	/etc/rc.backup_logs.sh
-fi
+. /etc/rc.ramdisk_functions.sh
+ramdisk_make_backup
 
 # Invoke shutdown scripts if present
 scripts=/usr/local/etc/rc.d/shutdown.*.sh

--- a/src/etc/rc.bootup
+++ b/src/etc/rc.bootup
@@ -360,6 +360,11 @@ if ($physmem < $g['minimum_ram_warning']) {
 	));
 }
 
+if (file_exists("/conf/ram_disks_failed")) {
+	require_once("/etc/inc/notices.inc");
+	file_notice("RAM Disks", "RAM disk creation failed. Reverted to traditional storage. Check RAM disk sizes.", "RAM Disks");
+}
+
 /* if we are operating at 1000 then increase timeouts.
    this was never accounted for after moving to 1000 hz */
 $kern_hz = get_single_sysctl('kern.clockrate');

--- a/src/etc/rc.embedded
+++ b/src/etc/rc.embedded
@@ -20,31 +20,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Size of /tmp
-USE_MFS_TMP_SIZE=$(/usr/local/sbin/read_xml_tag.sh string system/use_mfs_tmp_size)
-if [ -n "${USE_MFS_TMP_SIZE}" ] && [ ${USE_MFS_TMP_SIZE} -gt 0 ]; then
-	tmpsize="${USE_MFS_TMP_SIZE}m"
-else
-	tmpsize="40m"
-fi
-
-# Size of /var
-USE_MFS_VAR_SIZE=$(/usr/local/sbin/read_xml_tag.sh string system/use_mfs_var_size)
-if [ -n "${USE_MFS_VAR_SIZE}" ] && [ ${USE_MFS_VAR_SIZE} -gt 0 ]; then
-	varsize="${USE_MFS_VAR_SIZE}m"
-else
-	varsize="60m"
-fi
+. /etc/rc.ramdisk_functions.sh
 
 echo -n "Setting up memory disks..."
-mdmfs -S -M -s ${tmpsize} md /tmp
-mdmfs -S -M -s ${varsize} md /var
 
-# Create some needed directories
-/bin/mkdir -p /var/db /var/spool/lock
-/usr/sbin/chown uucp:dialer /var/spool/lock
-
-# Ensure vi's recover directory is present
-/bin/mkdir -p /var/tmp/vi.recover/
-/bin/mkdir -p /var/crash/
-echo " done."
+if ramdisk_check_size && ramdisk_try_mount tmp && ramdisk_try_mount var; then
+	/bin/rm -f ${RAMDISK_FLAG_FILE}
+	# Create some needed directories
+	/bin/mkdir -p /var/db /var/spool/lock
+	/usr/sbin/chown uucp:dialer /var/spool/lock
+	# Ensure vi's recover directory is present
+	/bin/mkdir -p /var/tmp/vi.recover/
+	/bin/mkdir -p /var/crash/
+	echo " done."
+else
+	/usr/bin/touch ${RAMDISK_FLAG_FILE}
+	/sbin/umount -f /tmp /var 2>/dev/null
+	echo " failed."
+fi

--- a/src/etc/rc.ramdisk_functions.sh
+++ b/src/etc/rc.ramdisk_functions.sh
@@ -1,0 +1,204 @@
+#!/bin/sh
+#
+# rc.ramdisk_functions.sh
+#
+# part of pfSense (https://www.pfsense.org)
+# Copyright (c) 2020 Rubicon Communications, LLC (Netgate)
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Source like so:
+#     . /etc/rc.ramdisk_functions.sh
+# Then use these variables and functions wherever RAM disk operations are needed
+
+RAMDISK_FLAG_FILE=/conf/ram_disks_failed
+RAMDISK_DEFAULT_SIZE_tmp=40
+RAMDISK_DEFAULT_SIZE_var=60
+
+# Check if RAM disks are enabled in config.xml
+ramdisk_check_enabled () {
+	[ "$(/usr/local/sbin/read_xml_tag.sh boolean system/use_mfs_tmpvar)" = "true" ]
+	return $?
+}
+
+# Checks that RAM disks are both enabled and that they have not failed
+ramdisk_is_active () {
+	ramdisk_check_enabled && [ ! -e ${RAMDISK_FLAG_FILE} ]
+	return $?
+}
+
+# Checks if RAM disk setup failed
+ramdisk_failed () {
+	[ -e ${RAMDISK_FLAG_FILE} ]
+	return $?
+}
+
+# Resets the RAM disk failure status
+ramdisk_reset_status () {
+	if [ -f ${RAMDISK_FLAG_FILE} ]; then
+		rm -f ${RAMDISK_FLAG_FILE}
+	fi
+}
+
+# Checks if RAM disks were active on a previous boot (or active now)
+ramdisk_was_active() {
+	# If /var is on a memory disk, then RAM disks are active now or were active and recently disabled
+	DISK_NAME=`/bin/df /var/db/rrd | /usr/bin/tail -1 | /usr/bin/awk '{print $1;}'`
+	DISK_TYPE=`/usr/bin/basename ${DISK_NAME} | /usr/bin/cut -c1-2`
+	[ "${DISK_TYPE}" = "md" ]
+	return $?
+}
+
+# Echos the effective size of the given RAM disk (var or tmp)
+# If set, use that value. If unset, use the default value
+# Usage example:
+#   tmpsize = $( ramdisk_get_size tmp )
+#   varsize = $( ramdisk_get_size var )
+ramdisk_get_size () {
+	NAME=${1}
+	DEFAULT_SIZE=$(eval echo \${RAMDISK_DEFAULT_SIZE_${NAME}})
+
+	SIZE=$(/usr/local/sbin/read_xml_tag.sh string system/use_mfs_${NAME}_size)
+	if [ -n "${SIZE}" ] && [ ${SIZE} -gt 0 ]; then
+		echo ${SIZE}
+	else
+		echo ${DEFAULT_SIZE}
+	fi
+	return 0
+}
+
+# Tests if the current total RAM disk size can fit in free kernel memory
+ramdisk_check_size () {
+	tmpsize=$( ramdisk_get_size tmp )
+	varsize=$( ramdisk_get_size var )
+	# Check available kmem
+	KMEM_FREE=$( /sbin/sysctl -n vm.kmem_map_free )
+	# Convert to MB
+	KMEM_FREE=$( /bin/expr ${KMEM_FREE} / 1024 / 1024 )
+	# Total size of desired RAM disks
+	KMEM_NEED=$( /bin/expr ${tmpsize} + ${varsize} )
+	# echo "FREE: ${KMEM_FREE} NEED: ${KMEM_NEED}"
+	[ ${KMEM_FREE} -gt ${KMEM_NEED} ]
+	return $?
+}
+
+# Attempt to mount the given RAM disk (var or tmp)
+# Usage:
+#   ramdisk_try_mount tmp
+#   ramdisk_try_mount var
+ramdisk_try_mount () {
+	NAME=$1
+	if [ ramdisk_check_size ]; then
+		SIZE=$(eval echo \${${NAME}size})m
+		/sbin/mdmfs -S -M -s ${SIZE} md /${NAME}
+		return $?
+	else
+		return 1;
+	fi
+}
+
+# If the install has RAM disks, or if the full install _was_ using RAM disks, make a backup.
+ramdisk_make_backup () {
+	if ramdisk_is_active || ramdisk_was_active; then
+		echo "Backing up RAM disk contents"
+		/etc/rc.backup_aliastables.sh
+		/etc/rc.backup_rrd.sh
+		/etc/rc.backup_dhcpleases.sh
+		/etc/rc.backup_logs.sh
+	fi
+}
+
+# Relocate the pkg database to a specific given location, either disk (/var) or
+#   to its safe location for use with RAM disks (/root/var)
+# Usage:
+#   ramdisk_relocate_pkgdb disk
+#   ramdisk_relocate_pkgdb ram
+ramdisk_relocate_pkgdb () {
+	if [ ${1} = "disk" ]; then
+		local SRC=/root
+		local DST=
+	else
+		local SRC=
+		local DST=/root
+	fi
+
+	echo "Moving pkg database for ${1} storage"
+	if [ -d ${SRC}/var/db/pkg ]; then
+		echo "Clearing ${DST}/var/db/pkg"
+		rm -rf ${DST}/var/db/pkg 2>/dev/null
+		/bin/mkdir -p ${DST}/var/db
+		echo "Moving ${SRC}/var/db/pkg to ${DST}/var/db/"
+		mv -f ${SRC}/var/db/pkg ${DST}/var/db
+	fi
+	if [ -d ${SRC}/var/cache/pkg ]; then
+		echo "Clearing ${DST}/var/cache/pkg"
+		rm -rf ${DST}/var/cache/pkg 2>/dev/null
+		/bin/mkdir -p ${DST}/var/cache
+		echo "Moving ${SRC}/var/cache/pkg to ${DST}/var/cache/"
+		mv -f ${SRC}/var/cache/pkg ${DST}/var/cache
+	fi
+}
+
+# Relocate the pkg database as needed based on RAM disk options and status
+ramdisk_relocate_pkgdb_all () {
+	unset MOVE_PKG_DATA
+	unset USE_RAMDISK
+	if ramdisk_check_enabled; then
+		USE_RAMDISK=true
+	fi
+	if [ -z "${USE_RAMDISK}" -a -f /root/var/db/pkg/local.sqlite ]; then
+		if ramdisk_failed; then
+			echo "Not relocating pkg db due to previous RAM disk failure."
+			return 1
+		fi
+		# If RAM disks are disabled, move files back into place
+		MOVE_PKG_DATA=1
+		ramdisk_relocate_pkgdb disk
+	elif [ -n "${USE_RAMDISK}" -a -f /var/db/pkg/local.sqlite ]; then
+		# If RAM disks are enabled, move files to a safe place
+		MOVE_PKG_DATA=1
+		ramdisk_relocate_pkgdb ram
+	fi
+}
+
+# Setup symbolic links for the pkg database
+ramdisk_link_pkgdb () {
+	/bin/mkdir -p /var/db /var/cache
+	if [ ! -e /var/db/pkg ]; then
+		echo "Creating pkg db symlink"
+		ln -sf ../../root/var/db/pkg /var/db/pkg
+	fi
+	if [ ! -e /var/cache/pkg ]; then
+		echo "Creating pkg cache symlink"
+		ln -sf ../../root/var/cache/pkg /var/cache/pkg
+	fi
+}
+
+# Either unmount or mount /var and /tmp in ZFS as needed to avoid conflicts with
+#   active RAM disk options.
+ramdisk_fixup_zfs () {
+	# Mount /var and /tmp on ZFS filesystems when necessary
+	if [ ${1} = "mount" ]; then
+		echo "Remounting ZFS volumes"
+		zfs mount -a
+	else
+		zfs list -H -o name,mountpoint |
+		    while read volume mountpoint; do
+			[ "${mountpoint}" != "/var" -a "${mountpoint}" != "/tmp" ] \
+				&& continue
+			echo "Dismounting ZFS volume ${volume} for RAM disk"
+			/sbin/zfs umount ${volume}
+		done
+	fi
+}

--- a/src/etc/rc.reboot
+++ b/src/etc/rc.reboot
@@ -38,16 +38,8 @@ product=$(/usr/local/sbin/read_global_var product_name pfSense)
 # Remove temporary files on shutdown from /tmp/
 rm -rf /tmp/*
 
-USE_MFS_TMPVAR=$(/usr/local/sbin/read_xml_tag.sh boolean system/use_mfs_tmpvar)
-DISK_NAME=`/bin/df /var/db/rrd | /usr/bin/tail -1 | /usr/bin/awk '{print $1;}'`
-DISK_TYPE=`/usr/bin/basename ${DISK_NAME} | /usr/bin/cut -c1-2`
-# If we are not on a full install, or if the full install wants RAM disks, or if the full install _was_ using RAM disks, but isn't for the next boot...
-if [ "${USE_MFS_TMPVAR}" = "true" ] || [ "${DISK_TYPE}" = "md" ]; then
-	/etc/rc.backup_aliastables.sh
-	/etc/rc.backup_rrd.sh
-	/etc/rc.backup_dhcpleases.sh
-	/etc/rc.backup_logs.sh
-fi
+. /etc/rc.ramdisk_functions.sh
+ramdisk_make_backup
 
 sleep 1
 

--- a/src/etc/rc.restore_ramdisk_store
+++ b/src/etc/rc.restore_ramdisk_store
@@ -22,6 +22,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+. /etc/rc.ramdisk_functions.sh
+
 # Wildcard file existence check function
 wildcard_file_exists() {
 	for file in "$1"; do
@@ -43,8 +45,6 @@ if wildcard_file_exists "${RAM_Disk_Store}/"*".tgz"; then
 	mesg="Restoring contents of RAM disk store..."
 	echo -n "$mesg"
 
-	USE_MFS_TMPVAR=$(/usr/local/sbin/read_xml_tag.sh boolean system/use_mfs_tmpvar)
-
 	# Restore the ram disk
 	for backup_file in "${RAM_Disk_Store}/"*".tgz"; do
 		if [ -f "$backup_file" ]; then
@@ -59,7 +59,7 @@ if wildcard_file_exists "${RAM_Disk_Store}/"*".tgz"; then
 			mesg="$mesg\nRAM disk restore succeeded: $backup_file"
 
 			#If this backup is still there on a full install, but we aren't going to use ram disks, remove the archive since this is a transition.
-			if [ "${USE_MFS_TMPVAR}" != "true" ]; then
+			if ! ramdisk_is_active; then
 				/bin/rm -f "${backup_file}"
 			fi
 		fi

--- a/src/etc/skel/dot.shrc
+++ b/src/etc/skel/dot.shrc
@@ -35,7 +35,7 @@ if [ "${HTTP_PROXY_AUTH_USER}" != "" ] && [ "${HTTP_PROXY_AUTH_PASS}" != "" ]; t
 fi
 
 USE_MFS_TMPVAR=$(/usr/local/sbin/read_xml_tag.sh boolean system/use_mfs_tmpvar)
-if [ "${USE_MFS_TMPVAR}" = "true" ]; then
+if [ "${USE_MFS_TMPVAR}" = "true" ] && [ ! -f /conf/ram_disks_failed ]; then
 	export PKG_DBDIR='/root/var/db/pkg'
 	export PKG_CACHEDIR='/root/var/cache/pkg'
 fi

--- a/src/etc/skel/dot.tcshrc
+++ b/src/etc/skel/dot.tcshrc
@@ -64,7 +64,7 @@ if ( ${http_proxy_auth_user} != "" && ${http_proxy_auth_pass} != "" ) then
 endif
 
 set use_mfs_tmpvar=`/usr/local/sbin/read_xml_tag.sh boolean system/use_mfs_tmpvar`
-if ( $use_mfs_tmpvar == "true" ) then
+if ( $use_mfs_tmpvar == "true" && ! -f "/conf/ram_disks_failed" ) then
 	setenv PKG_DBDIR '/root/var/db/pkg'
 	setenv PKG_CACHEDIR '/root/var/cache/pkg'
 endif

--- a/src/usr/local/www/system_advanced_misc.php
+++ b/src/usr/local/www/system_advanced_misc.php
@@ -53,6 +53,8 @@ $mds_modes = array(
 	3 => gettext('Automatic VERW or Software selection'),
 );
 
+$available_kernel_memory = get_single_sysctl("vm.kmem_map_free");
+
 $pconfig['proxyurl'] = $config['system']['proxyurl'];
 $pconfig['proxyport'] = $config['system']['proxyport'];
 $pconfig['proxyuser'] = $config['system']['proxyuser'];
@@ -122,6 +124,11 @@ if ($_POST) {
 
 	if (!empty($_POST['use_mfs_var_size']) && (!is_numeric($_POST['use_mfs_var_size']) || ($_POST['use_mfs_var_size'] < 60))) {
 		$input_errors[] = gettext("/var Size must be numeric and should not be less than 60MiB.");
+	}
+
+	if (is_numericint($_POST['use_mfs_tmp_size']) && is_numericint($_POST['use_mfs_var_size']) &&
+	    ((($_POST['use_mfs_tmp_size'] + $_POST['use_mfs_var_size']) * 1024 * 1024) > $available_kernel_memory)) {
+		$input_errors[] = gettext("Combined size of /tmp and /var RAM disks would exceed free kernel memory.");
 	}
 
 	if (!empty($_POST['proxyport']) && !is_port($_POST['proxyport'])) {
@@ -582,7 +589,10 @@ $group->add(new Form_Input(
 	['placeholder' => 60]
 ))->setHelp('/var RAM Disk<br />Do not set lower than 60.');
 
-$group->setHelp('Sets the size, in MiB, for the RAM disks.');
+$group->setHelp('Sets the size, in MiB, for the RAM disks. ' .
+	'Ensure each RAM disk is large enough to contain the current contents of the directories in question. %s' .
+	'Maximum total size of all RAM disks cannot exceed free kernel memory: %s',
+	'<br/>', format_bytes( $available_kernel_memory ));
 
 $section->add($group);
 
@@ -649,7 +659,8 @@ $form->add($section);
 print $form;
 
 $ramdisk_msg = gettext('The \"Use Ramdisk\" setting has been changed. This requires the firewall\nto reboot.\n\nReboot now ?');
-$use_mfs_tmpvar_changed = (($use_mfs_tmpvar_before !== $use_mfs_tmpvar_after) && !$input_errors);
+$use_mfs_tmpvar_changed = ((($use_mfs_tmpvar_before !== $use_mfs_tmpvar_after) ||
+			    (!empty($_POST) && $use_mfs_tmpvar_after && file_exists('/conf/ram_disks_failed'))) && !$input_errors);
 ?>
 
 <script type="text/javascript">


### PR DESCRIPTION
* Prevents RAM disk from being partially enabled and left in a broken
state if the RAM disks cannot be created
* Prevents RAM disks from potentially overcommitting free kernel memory,
which FreeBSD now prevents, but could result in errors.
* Adds GUI input validation to prevent exceeding free kernel memory when
sizing RAM disks
* Ensures the pkg database is always available whether setup for disk
storage, RAM disks, or if set for RAM disks but they failed to work
* Moves RAM disk script functions to a common file for reuse.
* Files a notice to alert the user that RAM disks failed and to check
the disk sizes
* Generally makes the RAM disk setup process more verbose on the
console. These messages can be commented out or removed in the future,
but are helpful for the time being.

- [ ] Redmine Issue: https://redmine.pfsense.org/issues/NNNN
- [ ] Ready for review