### PR TITLE
Ignore the UFS journal when pfSense tries to fix a disk corruption.

### DIFF
--- a/src/etc/pfSense-rc
+++ b/src/etc/pfSense-rc
@@ -71,7 +71,7 @@ fsck_forced_iterations=`/bin/kenv -q pfsense.fsck.force`
 if [ ! -z "${fsck_forced_iterations}" ]; then
 	echo "Forcing filesystem check (${fsck_forced_iterations} times)..."
 	while [ ${fsck_forced_iterations} -gt 0 ]; do
-		/sbin/fsck -y -t ufs
+		/sbin/fsck -fy -t ufs
 		fsck_forced_iterations=$((fsck_forced_iterations - 1))
 	done
 fi
@@ -118,14 +118,14 @@ esac
 
 if [ ${FSCK_ACTION_NEEDED} = 1 ]; then
 	echo "WARNING: Trying to recover filesystem from inconsistency..."
-	/sbin/fsck -y -t ufs
+	/sbin/fsck -fy -t ufs
 fi
 
 /sbin/mount -a 2>/dev/null
 mount_rc=$?
 attempts=0
 while [ ${mount_rc} -ne 0 -a ${attempts} -lt 10 ]; do
-	/sbin/fsck -y -t ufs
+	/sbin/fsck -fy -t ufs
 	/sbin/mount -a 2>/dev/null
 	mount_rc=$?
 	attempts=$((attempts+1))


### PR DESCRIPTION
Not all UFS issues are present on journal, which can make the fsck miss some
issues.

This change improves the pfSense chances of fixing UFS issues.

(cherry picked from commit 8d90b8752ae9127dff1f145a2ec5d3d2fdcad56d)

- [ ] Redmine Issue: https://redmine.pfsense.org/issues/NNNN
- [ ] Ready for review