### PR TITLE
Add AutoIP dynamic DNS provider

### DIFF
--- a/src/etc/inc/dyndns.class
+++ b/src/etc/inc/dyndns.class
@@ -25,9 +25,10 @@
 	 * PHP.updateDNS (pfSense version)
 	 *
 	 * +====================================================+
-	 *  Services Supported:
-	 *    - All-Inkl (all-inkl.com)
-	 *    - Amazon Route 53 (aws.amazon.com)
+         *  Services Supported:
+         *    - All-Inkl (all-inkl.com)
+         *    - AutoIP (autoip.com.br)
+         *    - Amazon Route 53 (aws.amazon.com)
 	 *    - Azure DNS (azure.microsoft.com)
 	 *    - City Network (citynetwork.se)
 	 *    - Cloudflare (www.cloudflare.com)
@@ -93,8 +94,9 @@
 	 *    - _debug()
 	 *    - _checkIP()
 	 * +----------------------------------------------------+
-	 *  All-Inkl        - Last Tested: 12 November 2016
-	 *  Amazon Route 53 - Last Tested: 04 February 2017
+        *  All-Inkl        - Last Tested: 12 November 2016
+        *  AutoIP          - Last Tested: NEVER
+        *  Amazon Route 53 - Last Tested: 04 February 2017
 	 *  Azure DNS       - Last Tested: 08 March 2018
 	 *  City Network    - Last Tested: 13 November 2013
 	 *  Cloudflare      - Last Tested: 05 September 2016
@@ -182,22 +184,23 @@
 		var $_dnsPort;
 		var $_dnsUpdateURL;
 		var $_dnsZoneID;
-		var $_dnsTTL;
-		var $status;
-		var $_debugID;
-		var $_if;
-		var $_dnsResultMatch;
-		var $_dnsRequestIf;
-		var $_dnsRequestIfIP;
-		var $_dnsVerboseLog;
-		var $_curlIpresolveV4;
-		var $_curlSslVerifypeer;
-		var $_dnsMaxCacheAgeDays;
-		var $_dnsDummyUpdateDone;
-		var $_forceUpdateNeeded;
-		var $_useIPv6;
-		var $_existingRecords;
-		var $_curlProxy;
+                var $_dnsTTL;
+                var $status;
+                var $_debugID;
+                var $_if;
+                var $_dnsResultMatch;
+                var $_dnsRequestIf;
+                var $_dnsRequestIfIP;
+                var $_dnsVerboseLog;
+                var $_curlIpresolveV4;
+                var $_curlSslVerifypeer;
+                var $_dnsMaxCacheAgeDays;
+                var $_dnsDummyUpdateDone;
+                var $_forceUpdateNeeded;
+                var $_useIPv6;
+                var $_existingRecords;
+               var $_curlProxy;
+               var $_dnsDescr;
 
 		/*
 		 * Public Constructor Function (added 12 July 05) [beta]
@@ -212,8 +215,8 @@
 					$dnsWildcard = 'OFF', $dnsProxied = false, $dnsMX = '', $dnsIf = '', $dnsBackMX = '',
 					$dnsServer = '', $dnsPort = '', $dnsUpdateURL = '', $forceUpdate = false,
 					$dnsZoneID ='', $dnsTTL='', $dnsResultMatch = '', $dnsRequestIf = '', $dnsMaxCacheAge = '',
-					$dnsID = '', $dnsVerboseLog = false, $curlIpresolveV4 = false, $curlSslVerifypeer = true,
-					$curlProxy = false) {
+                                       $dnsID = '', $dnsVerboseLog = false, $curlIpresolveV4 = false, $curlSslVerifypeer = true,
+                                       $curlProxy = false, $dnsDescr = '') {
 
 			global $config, $g, $dyndns_split_domain_types;
 			if (in_array($dnsService, $dyndns_split_domain_types)) {
@@ -226,10 +229,11 @@
 			$this->_cacheFile_v6 = "{$g['conf_path']}/dyndns_{$dnsIf}{$dnsService}" . escapeshellarg($this->_FQDN) . "{$dnsID}_v6.cache";
 			$this->_debugFile = "{$g['varetc_path']}/dyndns_{$dnsIf}{$dnsService}" . escapeshellarg($this->_FQDN) . "{$dnsID}.debug";
 
-			$this->_curlIpresolveV4 = $curlIpresolveV4;
-			$this->_curlSslVerifypeer = $curlSslVerifypeer;
-			$this->_curlProxy = $curlProxy;
-			$this->_dnsVerboseLog = $dnsVerboseLog;
+                       $this->_curlIpresolveV4 = $curlIpresolveV4;
+                       $this->_curlSslVerifypeer = $curlSslVerifypeer;
+                       $this->_curlProxy = $curlProxy;
+                       $this->_dnsDescr = $dnsDescr;
+                       $this->_dnsVerboseLog = $dnsVerboseLog;
 			if ($this->_dnsVerboseLog) {
 				log_error(gettext("Dynamic DNS: updatedns() starting"));
 			}
@@ -408,8 +412,9 @@
 				$this->_error(10);
 			} else {
 				switch ($this->_dnsService) {
-					case 'all-inkl':
-					case 'azure':
+                                       case 'all-inkl':
+                                       case 'autoip':
+                                       case 'azure':
 					case 'azurev6':
 					case 'citynetwork':
 					case 'cloudflare':
@@ -1323,17 +1328,30 @@
 					}
 					curl_setopt($ch, CURLOPT_URL, $server . $port . '?hostname=' . $this->_dnsHost . '&myip=' . $this->_dnsIP);
 					break;
-				case 'all-inkl':
-					$needsIP = FALSE;
-					$server = 'https://dyndns.kasserver.com/';
-					curl_setopt($ch, CURLOPT_USERPWD, $this->_dnsUser . ':' . $this->_dnsPass);
-					curl_setopt($ch, CURLOPT_URL, $server . 'myip=' . $this->_dnsIP);
-					break;
-				case 'hover':
-					$needsIP = FALSE;
-					$port = "";
-					curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-					curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 1);
+                                case 'all-inkl':
+                                        $needsIP = FALSE;
+                                        $server = 'https://dyndns.kasserver.com/';
+                                        curl_setopt($ch, CURLOPT_USERPWD, $this->_dnsUser . ':' . $this->_dnsPass);
+                                        curl_setopt($ch, CURLOPT_URL, $server . 'myip=' . $this->_dnsIP);
+                                        break;
+                               case 'autoip':
+                                       $needsIP = TRUE;
+                                       $server = 'https://update.autoip.com.br/nic/update';
+                                       $port = '';
+                                       if ($this->_dnsServer) {
+                                               $server = $this->_dnsServer;
+                                       }
+                                       if ($this->_dnsPort) {
+                                               $port = ':' . $this->_dnsPort;
+                                       }
+                                       curl_setopt($ch, CURLOPT_USERPWD, $this->_dnsUser . ':' . $this->_dnsPass);
+                                       curl_setopt($ch, CURLOPT_URL, $server . $port . '?hostname=' . $this->_dnsHost . '&myip=' . $this->_dnsIP . '&comment=' . rawurlencode($this->_dnsDescr));
+                                       break;
+                                case 'hover':
+                                        $needsIP = FALSE;
+                                        $port = "";
+                                        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+                                        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 1);
 
 					//step 1: login to API
 					$post_data['username'] = $this->_dnsUser;
@@ -2877,27 +2895,44 @@
 						$this->_debug($data);
 					}
 					break;
-				case 'all-inkl':
- 					if (preg_match('/good\s' . $this->_dnsIP . '/i', $data)) {
-							$status = $status_intro . $success_str . gettext("IP Address Changed Successfully!") . " (" . $this->_dnsIP . ")";
- 							$successful_update = true;
- 					} else if (preg_match('/good/i', $data)) {
-						$status = $status_intro . $error_str . gettext("Result did not match.");
-					} else if (preg_match("/\s401\sUnauthorized/i", $header)) {
-						$status = $status_intro . $error_str . gettext("Invalid username or password");
-					}
-					else {
-							$status = $status_intro . "(" . gettext("Unknown Response") . ")";
-							log_error($status_intro . gettext("PAYLOAD:") . " " . $header . $data);
- 							$this->_debug($data);
- 							$this->_debug($header);
- 					}
- 					break;
-				case 'hover':
-					if (preg_match('/succeeded":true/i', $data)) {
-						$status = $status_intro . $success_str . gettext("IP Address Changed Successfully!") . " (" . $this->_dnsIP . ")";
-						$successful_update = true;
-					} else {
+                               case 'all-inkl':
+                                       if (preg_match('/good\s' . $this->_dnsIP . '/i', $data)) {
+                                                       $status = $status_intro . $success_str . gettext("IP Address Changed Successfully!") . " (" . $this->_dnsIP . ")";
+                                                       $successful_update = true;
+                                       } else if (preg_match('/good/i', $data)) {
+                                               $status = $status_intro . $error_str . gettext("Result did not match.");
+                                       } else if (preg_match("/\s401\sUnauthorized/i", $header)) {
+                                               $status = $status_intro . $error_str . gettext("Invalid username or password");
+                                       }
+                                       else {
+                                                       $status = $status_intro . "(" . gettext("Unknown Response") . ")";
+                                                       log_error($status_intro . gettext("PAYLOAD:") . " " . $header . $data);
+                                                       $this->_debug($data);
+                                                       $this->_debug($header);
+                                       }
+                                       break;
+                               case 'autoip':
+                                       if (preg_match('/good/i', $data)) {
+                                               $status = $status_intro . $success_str . gettext("IP Address Changed Successfully!") . " (" . $this->_dnsIP . ")";
+                                               $successful_update = true;
+                                       } else if (preg_match('/nochg/i', $data)) {
+                                               $status = $status_intro . $success_str . gettext("No Change In IP Address");
+                                               $successful_update = true;
+                                       } else if (preg_match('/nohost/i', $data)) {
+                                               $status = $status_intro . $error_str . gettext("No such host");
+                                       } else if (preg_match('/noauth/i', $data)) {
+                                               $status = $status_intro . $error_str . gettext("User Authorization Failed");
+                                       } else {
+                                               $status = $status_intro . "(" . gettext("Unknown Response") . ")";
+                                               log_error($status_intro . gettext("PAYLOAD:") . " " . $data);
+                                               $this->_debug($data);
+                                       }
+                                       break;
+                               case 'hover':
+                                       if (preg_match('/succeeded":true/i', $data)) {
+                                               $status = $status_intro . $success_str . gettext("IP Address Changed Successfully!") . " (" . $this->_dnsIP . ")";
+                                               $successful_update = true;
+                                       } else {
 						$status = $status_intro . "(" . gettext("Unknown Response") . ")";
 						log_error($status_intro . gettext("PAYLOAD:") . " " . $data);
 						$this->_debug($data);

--- a/src/etc/inc/services.inc
+++ b/src/etc/inc/services.inc
@@ -26,8 +26,8 @@
  */
 
 
-define('DYNDNS_PROVIDER_VALUES', 'all-inkl azure azurev6 citynetwork cloudflare cloudflare-v6 cloudns custom custom-v6 desec desec-v6 digitalocean digitalocean-v6 dnsexit dnsimple dnsimple-v6 dnsmadeeasy dnsomatic domeneshop domeneshop-v6 dreamhost dreamhost-v6 duiadns duiadns-v6 dyfi dyndns dyndns-custom dyndns-static dyns dynv6 dynv6-v6 easydns easydns-v6 eurodns freedns freedns-v6 freedns2 freedns2-v6 glesys gandi-livedns gandi-livedns-v6 godaddy godaddy-v6 googledomains gratisdns he-net he-net-v6 he-net-tunnelbroker hover linode linode-v6 loopia mythicbeasts mythicbeasts-v6 name.com name.com-v6 namecheap nicru nicru-v6 noip noip-v6 noip-free noip-free-v6 onecom onecom-v6 ods opendns ovh-dynhost route53 route53-v6 selfhost spdyn spdyn-v6 strato yandex yandex-v6 zoneedit porkbun porkbun-v6');
-define('DYNDNS_PROVIDER_DESCRIPTIONS', 'All-Inkl.com,Azure DNS,Azure DNS (v6),City Network,Cloudflare,Cloudflare (v6),ClouDNS,Custom,Custom (v6),deSEC,deSEC (v6),DigitalOcean,DigitalOcean (v6),DNSexit,DNSimple,DNSimple (v6),DNS Made Easy,DNS-O-Matic,Domeneshop,Domeneshop (v6),DreamHost,Dreamhost (v6),DuiaDns.net,DuiaDns.net (v6),DY.fi,DynDNS (dynamic),DynDNS (custom),DynDNS (static),DyNS,Dynv6,Dynv6 (v6),easyDNS,easyDNS (v6),Euro Dns,freeDNS,freeDNS (v6),freeDNS API Version 2, freeDNS API Version 2 (v6),GleSYS,Gandi LiveDNS,Gandi LiveDNS (v6),GoDaddy,GoDaddy (v6),Google Domains,GratisDNS,HE.net,HE.net (v6),HE.net Tunnelbroker,Hover,Linode,Linode (v6),Loopia,Mythic Beasts,Mythic Beasts (v6),Name.com,Name.com (v6),Namecheap,NIC.RU,NIC.RU (v6),No-IP,No-IP (v6),No-IP (free),No-IP (free-v6),One.com,One.com (v6),ODS.org,OpenDNS,OVH DynHOST,Route 53,Route 53 (v6),SelfHost,SPDYN,SPDYN (v6),Strato,Yandex,Yandex (v6),ZoneEdit,Porkbun,Porkbun (v6)');
+define('DYNDNS_PROVIDER_VALUES', 'all-inkl autoip azure azurev6 citynetwork cloudflare cloudflare-v6 cloudns custom custom-v6 desec desec-v6 digitalocean digitalocean-v6 dnsexit dnsimple dnsimple-v6 dnsmadeeasy dnsomatic domeneshop domeneshop-v6 dreamhost dreamhost-v6 duiadns duiadns-v6 dyfi dyndns dyndns-custom dyndns-static dyns dynv6 dynv6-v6 easydns easydns-v6 eurodns freedns freedns-v6 freedns2 freedns2-v6 glesys gandi-livedns gandi-livedns-v6 godaddy godaddy-v6 googledomains gratisdns he-net he-net-v6 he-net-tunnelbroker hover linode linode-v6 loopia mythicbeasts mythicbeasts-v6 name.com name.com-v6 namecheap nicru nicru-v6 noip noip-v6 noip-free noip-free-v6 onecom onecom-v6 ods opendns ovh-dynhost route53 route53-v6 selfhost spdyn spdyn-v6 strato yandex yandex-v6 zoneedit porkbun porkbun-v6');
+define('DYNDNS_PROVIDER_DESCRIPTIONS', 'All-Inkl.com,AutoIP,Azure DNS,Azure DNS (v6),City Network,Cloudflare,Cloudflare (v6),ClouDNS,Custom,Custom (v6),deSEC,deSEC (v6),DigitalOcean,DigitalOcean (v6),DNSexit,DNSimple,DNSimple (v6),DNS Made Easy,DNS-O-Matic,Domeneshop,Domeneshop (v6),DreamHost,Dreamhost (v6),DuiaDns.net,DuiaDns.net (v6),DY.fi,DynDNS (dynamic),DynDNS (custom),DynDNS (static),DyNS,Dynv6,Dynv6 (v6),easyDNS,easyDNS (v6),Euro Dns,freeDNS,freeDNS (v6),freeDNS API Version 2, freeDNS API Version 2 (v6),GleSYS,Gandi LiveDNS,Gandi LiveDNS (v6),GoDaddy,GoDaddy (v6),Google Domains,GratisDNS,HE.net,HE.net (v6),HE.net Tunnelbroker,Hover,Linode,Linode (v6),Loopia,Mythic Beasts,Mythic Beasts (v6),Name.com,Name.com (v6),Namecheap,NIC.RU,NIC.RU (v6),No-IP,No-IP (v6),No-IP (free),No-IP (free-v6),One.com,One.com (v6),ODS.org,OpenDNS,OVH DynHOST,Route 53,Route 53 (v6),SelfHost,SPDYN,SPDYN (v6),Strato,Yandex,Yandex (v6),ZoneEdit,Porkbun,Porkbun (v6)');
 
 /* implement ipv6 route advertising daemon */
 function services_radvd_configure($blacklist = array()) {
@@ -3942,8 +3942,9 @@ function services_dyndns_configure_client($conf) {
 		$dnsID = "{$conf['id']}",
 		$dnsVerboseLog = $conf['verboselog'],
 		$curlIpresolveV4 = $conf['curl_ipresolve_v4'],
-		$curlSslVerifypeer = $conf['curl_ssl_verifypeer'],
-		$curlProxy = $conf['curl_proxy']);
+               $curlSslVerifypeer = $conf['curl_ssl_verifypeer'],
+               $curlProxy = $conf['curl_proxy'],
+               $dnsDescr = $conf['descr']);
 }
 
 function services_dyndns_configure($int = "") {


### PR DESCRIPTION
## Summary
- support AutoIP dynamic DNS updates, building requests from hostname, IP, and description
- pass client descriptions into the Dynamic DNS updater and expose AutoIP in provider lists

## Testing
- `php -l src/etc/inc/services.inc`
- `php -l src/etc/inc/dyndns.class`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68955ea94244832e9baaa513dea0db21