### PR TITLE
Ensure pkg signing command allocates tty

### DIFF
--- a/tools/builder_defaults.sh
+++ b/tools/builder_defaults.sh
@@ -312,8 +312,10 @@ if [ -n "${_IS_RELEASE}" -o -n "${_IS_RC}" ]; then
 else
 	export PKG_REPO_SIGN_KEY=${PKG_REPO_SIGN_KEY:-"beta${PRODUCT_NAME_SUFFIX}"}
 fi
-# Command used to sign pkg repo
-: ${PKG_REPO_SIGNING_COMMAND="ssh -o StrictHostKeyChecking=no sign@codesigner.netgate.com sudo ./sign.sh ${PKG_REPO_SIGN_KEY}"}
+# Command used to sign pkg repo.  Force allocation of a pseudo-TTY (-tt) so the
+# remote sudo invocation succeeds even when the signing command is executed
+# outside of a pty (e.g., bootstrap package signing).
+: ${PKG_REPO_SIGNING_COMMAND="ssh -tt -o StrictHostKeyChecking=no sign@codesigner.netgate.com sudo ./sign.sh ${PKG_REPO_SIGN_KEY}"}
 export PKG_REPO_SIGNING_COMMAND
 export DO_NOT_SIGN_PKG_REPO=${DO_NOT_SIGN_PKG_REPO:-}
 


### PR DESCRIPTION
## Summary
- force ssh signing command to allocate a pseudo-TTY so remote sudo works during signing

## Testing
- not run (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695987027ee0832e98971224b1c15961)