### PR TITLE
Remove ALTABI handling from pkg setup

### DIFF
--- a/build/scripts/create_core_pkg.sh
+++ b/build/scripts/create_core_pkg.sh
@@ -44,7 +44,6 @@ Options:
 	-F filter    -- filter pattern to exclude files from plist
 	-d destdir   -- Destination directory to create package
 	-a ABI       -- Package ABI
-	-A ALTABI    -- Package ALTABI (aka arch)
 	-h           -- Show this help and exit
 
 Environment:
@@ -55,7 +54,7 @@ END
 	exit 1
 }
 
-while getopts s:t:f:v:r:F:d:ha:A: opt; do
+while getopts s:t:f:v:r:F:d:ha: opt; do
 	case "$opt" in
 		t)
 			template=$OPTARG
@@ -80,9 +79,6 @@ while getopts s:t:f:v:r:F:d:ha:A: opt; do
 			;;
 		a)
 			ABI=$OPTARG
-			;;
-		A)
-			ALTABI=$OPTARG
 			;;
 		*)
 			usage
@@ -187,11 +183,9 @@ if [ -d "${template_licensedir}" ]; then
 	done
 fi
 
-# Force desired ABI and arch
+# Force desired ABI
 [ -n "${ABI}" ] \
     && echo "abi: ${ABI}" >> ${manifest}
-[ -n "${ALTABI}" ] \
-    && echo "arch: ${ALTABI}" >> ${manifest}
 
 run "Creating core package ${template_name}" \
 	"pkg create -o ${destdir} -p ${plist} -r ${root} -m ${metadir}"

--- a/tools/templates/pkg_repos/Kontrol-repo-devel.altabi
+++ b/tools/templates/pkg_repos/Kontrol-repo-devel.altabi
@@ -1,1 +1,0 @@
-freebsd:15:%%ARCH%%

--- a/tools/templates/pkg_repos/Kontrol-repo-previous.altabi
+++ b/tools/templates/pkg_repos/Kontrol-repo-previous.altabi
@@ -1,1 +1,0 @@
-freebsd:14:%%ARCH%%

--- a/tools/templates/pkg_repos/Kontrol-repo.altabi
+++ b/tools/templates/pkg_repos/Kontrol-repo.altabi
@@ -1,1 +1,0 @@
-freeBSD:15:%%ARCH%%


### PR DESCRIPTION
## Summary
- remove ALTABI options from core package creation and repo setup
- drop ALTABI templates now that pkg no longer accepts manual ALTABI

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b0443047c832ea832ca4b68569f82)