### PR TITLE
Handle pkg repo metadata extensions (txz, tzst, pkg)

### DIFF
--- a/tools/builder_common.sh
+++ b/tools/builder_common.sh
@@ -85,8 +85,23 @@ core_pkg_create_repo() {
 	ln -sf .latest/All ${CORE_PKG_ALL_PATH}
 	#ln -sf .latest/digests.txz ${CORE_PKG_PATH}/digests.txz
 	ln -sf .latest/meta.conf ${CORE_PKG_PATH}/meta.conf
-	ln -sf .latest/meta.txz ${CORE_PKG_PATH}/meta.txz
-	ln -sf .latest/packagesite.txz ${CORE_PKG_PATH}/packagesite.txz
+
+	link_repo_metadata ${CORE_PKG_PATH} meta
+	link_repo_metadata ${CORE_PKG_PATH} packagesite
+}
+
+link_repo_metadata() {
+	local _repo_path="${1}"
+	local _name="${2}"
+	local _latest_dir="${_repo_path}/.latest"
+
+	for _ext in txz tzst pkg; do
+		if [ -f "${_latest_dir}/${_name}.${_ext}" ]; then
+			ln -sf ".latest/${_name}.${_ext}" \
+				"${_repo_path}/${_name}.${_ext}"
+			return 0
+		fi
+	done
 }
 
 	# Create core pkg (base, kernel)


### PR DESCRIPTION
### Motivation
- The `pkg` tool in newer FreeBSD (pkg 2.4.2 / FreeBSD 15) may emit repository metadata as `.tzst` or `.pkg` instead of the historical `.txz` files. 
- Existing repository symlink code expected `meta.txz` and `packagesite.txz`, which leaves repositories without expected links when `pkg` uses other extensions. 
- The change aims to keep repository layout compatible with poudriere-style snapshots by creating the same symlinks into the `.latest` directory. 

### Description
- Modified `tools/builder_common.sh` to replace fixed symlinks for `meta.txz` and `packagesite.txz` with a helper function. 
- Added `link_repo_metadata` which checks `.latest` for `meta`/`packagesite` files using extensions `txz`, `tzst`, and `pkg` and creates a symlink to the first match. 
- Retains the existing `meta.conf` symlink and the `pkg repo` invocation in `core_pkg_create_repo`. 
- The new logic uses `link_repo_metadata` from `core_pkg_create_repo` to handle multiple metadata formats transparently. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f97366034832ea924028007e0b673)