### PR TITLE
Fix core repo metadata links and preserve `tmp/pkg` until kernel install

### DIFF
--- a/tools/builder_common.sh
+++ b/tools/builder_common.sh
@@ -70,8 +70,12 @@ core_pkg_create_repo() {
 	ln -sf .latest/All ${CORE_PKG_ALL_PATH}
 	#ln -sf .latest/digests.txz ${CORE_PKG_PATH}/digests.txz
 	ln -sf .latest/meta.conf ${CORE_PKG_PATH}/meta.conf
-	ln -sf .latest/meta.txz ${CORE_PKG_PATH}/meta.txz
-	ln -sf .latest/packagesite.txz ${CORE_PKG_PATH}/packagesite.txz
+	for _ext in tzst txz; do
+		[ -f "${CORE_PKG_REAL_PATH}/meta.${_ext}" ] \
+			&& ln -sf ".latest/meta.${_ext}" "${CORE_PKG_PATH}/meta.${_ext}"
+		[ -f "${CORE_PKG_REAL_PATH}/packagesite.${_ext}" ] \
+			&& ln -sf ".latest/packagesite.${_ext}" "${CORE_PKG_PATH}/packagesite.${_ext}"
+	done
 }
 
 # Create core pkg (base, kernel)
@@ -373,6 +377,7 @@ create_ova_image() {
 	# Prepare folder to be put in image
 	customize_stagearea_for_image "ova"
 	install_default_kernel ${DEFAULT_KERNEL} "no"
+	cleanup_pkg_tmp
 
 	# Fill fstab
 	echo ">>> Installing platform specific items..." | tee -a ${LOGFILE}
@@ -761,9 +766,12 @@ customize_stagearea_for_image() {
 			${BUILDER_TOOLS}/templates/custom_logos/${_image_variant}/*.css \
 			${FINAL_CHROOT_DIR}/usr/local/share/${PRODUCT_NAME}/custom_logos
 	fi
+}
 
-	# Remove temporary repo conf
-	rm -rf ${FINAL_CHROOT_DIR}/tmp/pkg
+cleanup_pkg_tmp() {
+	if [ -n "${FINAL_CHROOT_DIR}" -a -d "${FINAL_CHROOT_DIR}/tmp/pkg" ]; then
+		rm -rf ${FINAL_CHROOT_DIR}/tmp/pkg
+	fi
 }
 
 create_distribution_tarball() {
@@ -804,6 +812,7 @@ create_iso_image() {
 
 	customize_stagearea_for_image "iso" "" $_variant
 	install_default_kernel ${DEFAULT_KERNEL}
+	cleanup_pkg_tmp
 
 	BOOTCONF=${INSTALLER_CHROOT_DIR}/boot.config
 	LOADERCONF=${INSTALLER_CHROOT_DIR}/boot/loader.conf
@@ -853,6 +862,7 @@ create_memstick_image() {
 
 	customize_stagearea_for_image "memstick" "" $_variant
 	install_default_kernel ${DEFAULT_KERNEL}
+	cleanup_pkg_tmp
 
 	echo ">>> Creating memstick to ${_image_path}." 2>&1 | tee -a ${LOGFILE}
 
@@ -897,6 +907,7 @@ create_memstick_serial_image() {
 
 	customize_stagearea_for_image "memstickserial"
 	install_default_kernel ${DEFAULT_KERNEL}
+	cleanup_pkg_tmp
 
 	echo ">>> Creating serial memstick to ${MEMSTICKSERIALPATH}." 2>&1 | tee -a ${LOGFILE}
 
@@ -945,6 +956,7 @@ create_memstick_adi_image() {
 
 	customize_stagearea_for_image "memstickadi"
 	install_default_kernel ${DEFAULT_KERNEL}
+	cleanup_pkg_tmp
 
 	echo ">>> Creating serial memstick to ${MEMSTICKADIPATH}." 2>&1 | tee -a ${LOGFILE}
 
@@ -999,6 +1011,25 @@ get_altabi_arch() {
 	fi
 }
 
+get_osversion() {
+	local _osversion=""
+
+	if [ -n "${FREEBSD_SRC_DIR}" -a -f "${FREEBSD_SRC_DIR}/sys/sys/param.h" ]; then
+		_osversion=$(awk '/^#define[[:space:]]+__FreeBSD_version/ {print $3; exit}' \
+			${FREEBSD_SRC_DIR}/sys/sys/param.h)
+	fi
+
+	if [ -z "${_osversion}" ]; then
+		_osversion=$(sysctl -n kern.osreldate 2>/dev/null)
+	fi
+
+	if [ -z "${_osversion}" ]; then
+		_osversion=$(uname -K 2>/dev/null)
+	fi
+
+	echo "${_osversion}"
+}
+
 # Create pkg conf on desired place with desired arch/branch
 setup_pkg_repo() {
 	if [ -z "${4}" ]; then
@@ -1048,17 +1079,16 @@ setup_pkg_repo() {
 		${_template} \
 		> ${_target}
 
-	local ALTABI_ARCH=$(get_altabi_arch ${_target_arch})
-
 	ABI=$(cat ${_template%%.conf}.abi 2>/dev/null \
 	    | sed -e "s/%%ARCH%%/${_target_arch}/g")
-	ALTABI=$(cat ${_template%%.conf}.altabi 2>/dev/null \
-	    | sed -e "s/%%ARCH%%/${ALTABI_ARCH}/g")
 
-	if [ -n "${_pkg_conf}" -a -n "${ABI}" -a -n "${ALTABI}" ]; then
+	if [ -n "${_pkg_conf}" -a -n "${ABI}" ]; then
 		mkdir -p $(dirname ${_pkg_conf})
 		echo "ABI=${ABI}" > ${_pkg_conf}
-		echo "ALTABI=${ALTABI}" >> ${_pkg_conf}
+		OSVERSION=$(get_osversion)
+		if [ -n "${OSVERSION}" ]; then
+			echo "OSVERSION=${OSVERSION}" >> ${_pkg_conf}
+		fi
 	fi
 }
 


### PR DESCRIPTION
### Motivation
- Avoid broken symlinks for core repository metadata when `meta.*`/`packagesite.*` are missing (e.g. only `.tzst` or `.txz` present) which breaks HTTP access to repos.
- Prevent `pkg` warnings and bootstrap failures caused by `pkg.conf` being removed too early during image generation while `install_default_kernel` or package operations run.
- Ensure `pkg` receives an explicit `OSVERSION` (and `ABI`) instead of forcing `ALTABI`, to accommodate newer `pkg` behavior that rejects manually-set `ALTABI`.

### Description
- Only create `meta.*` and `packagesite.*` symlinks in `core_pkg_create_repo()` when the corresponding file exists, iterating over `.tzst` and `.txz` extensions and avoiding broken links.
- Add `cleanup_pkg_tmp()` to remove `${FINAL_CHROOT_DIR}/tmp/pkg` and call it after `install_default_kernel` in `create_iso_image()`, `create_memstick_image()`, `create_memstick_serial_image()`, `create_memstick_adi_image()`, and `create_ova_image()` so temporary `pkg` config is preserved during kernel/package install.
- Update `setup_pkg_repo()` to stop writing `ALTABI` and instead write `ABI` and `OSVERSION` (using new `get_osversion()` that falls back to `sysctl` and `uname -K`) into generated `pkg.conf` when available.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696114b47770832e8c0fc6b345f1ba26)