### PR TITLE
Remover criação do pacote kernel-debug do build

### DIFF
--- a/tools/builder_common.sh
+++ b/tools/builder_common.sh
@@ -181,11 +181,6 @@ build_all_kernels() {
 
 		ensure_kernel_exists $KERNEL_DESTDIR
 
-		echo ">>> Creating pkg of $KERNEL_NAME-debug kernel to staging area..."  | tee -a ${LOGFILE}
-		core_pkg_create kernel-debug ${KERNEL_NAME} ${CORE_PKG_VERSION} ${KERNEL_DESTDIR} \
-		    "./usr/lib/debug/boot" \*.debug
-		rm -rf ${KERNEL_DESTDIR}/usr
-
 		echo ">>> Creating pkg of $KERNEL_NAME kernel to staging area..."  | tee -a ${LOGFILE}
 		core_pkg_create kernel ${KERNEL_NAME} ${CORE_PKG_VERSION} ${KERNEL_DESTDIR} "./boot/kernel ./boot/modules"
 


### PR DESCRIPTION
### Motivation
- Detectamos que o pacote `kernel-debug` não é referenciado nem consumido no fluxo de build, tornando sua geração desnecessária.
- Remover a etapa evita criação de artefatos redundantes e simplifica o processo de build.

### Description
- Removida a chamada que criava o pacote `kernel-debug` e o `rm -rf ${KERNEL_DESTDIR}/usr` associado dentro de `build_all_kernels` no arquivo `tools/builder_common.sh`.
- Mantida a criação do pacote de kernel principal via `core_pkg_create kernel` para `./boot/kernel` e `./boot/modules`.
- Os templates em `tools/templates/core_pkg/kernel-debug/` não foram alterados e permanecem no repositório.

### Testing
- Nenhum teste automatizado foi executado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69664e169224832eb97d660d85d7573b)