### PR TITLE
Verifica `repodata` antes de atualizar `packagesite`

### DIFF
--- a/tools/builder_common.sh
+++ b/tools/builder_common.sh
@@ -745,6 +745,14 @@ customize_stagearea_for_image() {
 			local _tgt_server="${PKG_REPO_SERVER_DEVEL}"
 		fi
 		for _db in ${FINAL_CHROOT_DIR}/var/db/pkg/repo-*sqlite; do
+			if [ ! -f "${_db}" ]; then
+				continue
+			fi
+			if ! /usr/local/bin/sqlite3 "${_db}" \
+				"select name from sqlite_master where type='table' and name='repodata'" \
+				| grep -q '^repodata$'; then
+				continue
+			fi
 			_cur=$(/usr/local/bin/sqlite3 ${_db} "${_read_cmd}")
 			_new=$(echo "${_cur}" | sed -e "s,^${PKG_REPO_SERVER_STAGING},${_tgt_server},")
 			/usr/local/bin/sqlite3 ${_db} "update repodata set value='${_new}' where key='packagesite'"


### PR DESCRIPTION
### Motivation
- Corrigir erro "Error: in prepare, no such table: repodata" que aparece ao criar a imagem ISO final.
- Evitar tentativas de atualizar o campo `packagesite` em bancos de dados de repositório que não possuem o schema esperado.
- Prevenir falhas repetidas durante a fase de preparação da imagem final que não quebram o build.

### Description
- Adicionada verificação de existência do ficheiro antes de operar sobre cada `repo-*sqlite` com `if [ ! -f "${_db}" ]`.
- Adicionada checagem do schema `repodata` usando `/usr/local/bin/sqlite3 "select name from sqlite_master ..."` e `grep -q '^repodata$'` para pular DBs sem a tabela.
- Mantido o fluxo original de leitura com `_read_cmd` e atualização da chave `packagesite` apenas quando a tabela existe.
- Alteração aplicada em `tools/builder_common.sh` na função `customize_stagearea_for_image` (bloco que trata `USE_PKG_REPO_STAGING`).

### Testing
- Nenhum teste automatizado foi executado durante esta alteração.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69666f603fc4832eb60bc039327d7d93)