### PR TITLE
Atualizar configuração do pkg para compatibilidade com FreeBSD 15

### DIFF
--- a/build/scripts/create_core_pkg.sh
+++ b/build/scripts/create_core_pkg.sh
@@ -44,7 +44,6 @@ Options:
 	-F filter    -- filter pattern to exclude files from plist
 	-d destdir   -- Destination directory to create package
 	-a ABI       -- Package ABI
-	-A ALTABI    -- Package ALTABI (aka arch)
 	-h           -- Show this help and exit
 
 Environment:
@@ -55,7 +54,7 @@ END
 	exit 1
 }
 
-while getopts s:t:f:v:r:F:d:ha:A: opt; do
+while getopts s:t:f:v:r:F:d:ha: opt; do
 	case "$opt" in
 		t)
 			template=$OPTARG
@@ -80,9 +79,6 @@ while getopts s:t:f:v:r:F:d:ha:A: opt; do
 			;;
 		a)
 			ABI=$OPTARG
-			;;
-		A)
-			ALTABI=$OPTARG
 			;;
 		*)
 			usage
@@ -187,11 +183,9 @@ if [ -d "${template_licensedir}" ]; then
 	done
 fi
 
-# Force desired ABI and arch
+# Force desired ABI
 [ -n "${ABI}" ] \
     && echo "abi: ${ABI}" >> ${manifest}
-[ -n "${ALTABI}" ] \
-    && echo "arch: ${ALTABI}" >> ${manifest}
 
 run "Creating core package ${template_name}" \
 	"pkg create -o ${destdir} -p ${plist} -r ${root} -m ${metadir}"

--- a/tools/builder_common.sh
+++ b/tools/builder_common.sh
@@ -89,12 +89,9 @@ core_pkg_create() {
 
 	local _template_path=${BUILDER_TOOLS}/templates/core_pkg/${_template}
 
-	# Use default pkg repo to obtain ABI and ALTABI
+	# Use default pkg repo to obtain ABI
 	local _abi=$(sed -e "s/%%ARCH%%/${TARGET_ARCH}/g" \
 	    ${PKG_REPO_DEFAULT%%.conf}.abi)
-	local _altabi_arch=$(get_altabi_arch ${TARGET_ARCH})
-	local _altabi=$(sed -e "s/%%ARCH%%/${_altabi_arch}/g" \
-	    ${PKG_REPO_DEFAULT%%.conf}.altabi)
 
 	${BUILDER_SCRIPTS}/create_core_pkg.sh \
 		-t "${_template_path}" \
@@ -105,7 +102,6 @@ core_pkg_create() {
 		-F "${_filter}" \
 		-d "${CORE_PKG_REAL_PATH}/All" \
 		-a "${_abi}" \
-		-A "${_altabi}" \
 		|| print_error_pfS
 }
 
@@ -1028,6 +1024,10 @@ get_osversion() {
 
 	if [ -z "${_osversion}" ]; then
 		_osversion=$(uname -K 2>/dev/null)
+	fi
+
+	if [ -z "${_osversion}" ]; then
+		_osversion=$(freebsd-version -k 2>/dev/null | cut -d '-' -f 1)
 	fi
 
 	echo "${_osversion}"

--- a/tools/builder_defaults.sh
+++ b/tools/builder_defaults.sh
@@ -297,9 +297,9 @@ export SKIP_FINAL_RSYNC=${SKIP_FINAL_RSYNC:-}
 
 # pkg repo variables
 export USE_PKG_REPO_STAGING="1"
-export PKG_REPO_SERVER_DEVEL=${PKG_REPO_SERVER_DEVEL:-"pkg+https://packages-beta.netgate.com/packages"}
-export PKG_REPO_SERVER_RELEASE=${PKG_REPO_SERVER_RELEASE:-"pkg+https://packages.netgate.com"}
-export PKG_REPO_SERVER_STAGING=${PKG_REPO_SERVER_STAGING:-"pkg+http://${STAGING_HOSTNAME}/ce/packages"}
+export PKG_REPO_SERVER_DEVEL=${PKG_REPO_SERVER_DEVEL:-"https://packages-beta.netgate.com/packages"}
+export PKG_REPO_SERVER_RELEASE=${PKG_REPO_SERVER_RELEASE:-"https://packages.netgate.com"}
+export PKG_REPO_SERVER_STAGING=${PKG_REPO_SERVER_STAGING:-"http://${STAGING_HOSTNAME}/ce/packages"}
 
 if [ -n "${_IS_RELEASE}" -o -n "${_IS_RC}" ]; then
 	export PKG_REPO_BRANCH_STAGING=${PKG_REPO_BRANCH_STAGING:-${PKG_REPO_BRANCH_RELEASE}}


### PR DESCRIPTION
### Motivation
- Corrigir avisos e comportamentos do `pkg` no FreeBSD 15 decorrentes do uso de `ALTABI` e da falta de `OSVERSION` ao gerar `pkg.conf`.
- Evitar que o `pkg` realize lookup SRV causado pelo esquema `pkg+https` nos endpoints de repositório.

### Description
- Removi o uso de `ALTABI` na criação de core packages e parei de passar o valor `arch` ao gerar o `+MANIFEST` para não usar a opção obsoleta do `pkg` (`tools/builder_common.sh` e `build/scripts/create_core_pkg.sh`).
- Ajustei o parser de opções de `create_core_pkg.sh` para eliminar a opção `-A/ALTABI` e mantive apenas `-a/ABI` ao criar pacotes (`build/scripts/create_core_pkg.sh`).
- Adicionei um fallback para detectar `OSVERSION` usando `freebsd-version -k` para garantir que o `pkg.conf` gerado inclua tanto `ABI` quanto `OSVERSION` quando possível (`tools/builder_common.sh`).
- Troquei os endpoints default de repositório para usar URLs HTTPS simples (removendo o prefixo `pkg+`) para evitar consultas SRV do `pkg` (`tools/builder_defaults.sh`).

### Testing
- Não foram executados testes automatizados nesta alteração.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966c87cc5dc832eabd14b6c31d9dad4)