### PR TITLE
Provide fallback write_config descriptions for package edits

### DIFF
--- a/src/usr/local/www/pkg_edit.php
+++ b/src/usr/local/www/pkg_edit.php
@@ -133,7 +133,16 @@ if ($_POST) {
 			}
 			eval($pkg['custom_delete_php_command']);
 		}
-		write_config($pkg['delete_string']);
+		$write_desc = $pkg['delete_string'];
+		if (empty($write_desc)) {
+			$pkg_label = $pkg['title'] ?: $pkg['name'];
+			if (!empty($pkg_label)) {
+				$write_desc = sprintf(gettext("Package %s configuration item deleted."), $pkg_label);
+			} else {
+				$write_desc = gettext("Package configuration item deleted.");
+			}
+		}
+		write_config($write_desc);
 		// resync the configuration file code if defined.
 		if ($pkg['custom_php_resync_config_command'] != "") {
 			if ($pkg['custom_php_command_before_form'] != "") {
@@ -219,7 +228,16 @@ if ($_POST) {
 				config_set_path("{$pkg_config_path}/", $pkgarr);
 			}
 
-			write_config($pkg['addedit_string']);
+			$write_desc = $pkg['addedit_string'];
+			if (empty($write_desc)) {
+				$pkg_label = $pkg['title'] ?: $pkg['name'];
+				if (!empty($pkg_label)) {
+					$write_desc = sprintf(gettext("Package %s configuration updated."), $pkg_label);
+				} else {
+					$write_desc = gettext("Package configuration updated.");
+				}
+			}
+			write_config($write_desc);
 			// late running code
 			if ($pkg['custom_add_php_command_late'] != "") {
 				eval($pkg['custom_add_php_command_late']);


### PR DESCRIPTION
### Motivation
- Avoid the `WARNING: write_config() was called without description` message when a package XML omits `addedit_string` or `delete_string` by supplying a sensible default description using the package `title` or `name`.

### Description
- Update `src/usr/local/www/pkg_edit.php` to compute a `$write_desc` for delete operations using `$pkg['delete_string']` with a fallback message that includes the package `title` or `name` when available.
- Add the same fallback logic for save/update operations, using `$pkg['addedit_string']` or a generated message including the package label.
- Call `write_config($write_desc)` in place of the raw `$pkg['...']` strings so `write_config()` always receives a non-empty description.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696842f83ff4832ea2dacd95560586c1)