### PR TITLE
Fix disk widget autoload path for Kontrol Filesystems

### DIFF
--- a/src/usr/local/www/widgets/include/disks.inc
+++ b/src/usr/local/www/widgets/include/disks.inc
@@ -19,7 +19,12 @@
  * limitations under the License.
  */
 
-require_once('vendor/autoload.php');
+$kontrol_autoload = '/usr/local/Kontrol/include/vendor/autoload.php';
+if (file_exists($kontrol_autoload)) {
+	require_once($kontrol_autoload);
+} else {
+	require_once('vendor/autoload.php');
+}
 
 use Kontrol\Services\Filesystem\{
 	Filesystem,

--- a/src/usr/local/www/widgets/widgets/disks.widget.php
+++ b/src/usr/local/www/widgets/widgets/disks.widget.php
@@ -20,7 +20,12 @@
  */
 
 // Composer autoloader
-require_once('vendor/autoload.php');
+$kontrol_autoload = '/usr/local/Kontrol/include/vendor/autoload.php';
+if (file_exists($kontrol_autoload)) {
+	require_once($kontrol_autoload);
+} else {
+	require_once('vendor/autoload.php');
+}
 
 // pfSense includes
 require_once('guiconfig.inc');


### PR DESCRIPTION
### Motivation
* O widget de discos gerava `Class "Kontrol\Services\Filesystem\Filesystems" not found` porque o `require_once('vendor/autoload.php')` usado pelo widget não carregava o autoloader do Composer instalado em `/usr/local/Kontrol/include`, logo o namespace `Kontrol\` não estava registrado.

### Description
* Ajusta o carregamento do autoloader nos pontos do widget para primeiro tentar `/usr/local/Kontrol/include/vendor/autoload.php` e, se não existir, usar o `vendor/autoload.php` relativo, alterando `src/usr/local/www/widgets/include/disks.inc` e `src/usr/local/www/widgets/widgets/disks.widget.php`.

### Testing
* Nenhum teste automatizado foi executado; as mudanças foram verificadas por inspeção do código e commit local.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d7891f368832eb6a27b7ab0459dc5)