### PR TITLE
Corrige fallback de autoload do widget de disco para caminhos de upgrade

### DIFF
--- a/src/usr/local/www/widgets/include/disks.inc
+++ b/src/usr/local/www/widgets/include/disks.inc
@@ -26,6 +26,22 @@ if (file_exists($kontrol_autoload)) {
 	require_once('vendor/autoload.php');
 }
 
+if (!class_exists('Kontrol\\Services\\Filesystem\\Filesystems')) {
+	$kontrol_filesystem_root = '/usr/local/Kontrol/include/Services/Filesystem';
+	$kontrol_filesystem_fallbacks = array(
+		"{$kontrol_filesystem_root}/Filesystem.php",
+		"{$kontrol_filesystem_root}/Provider/AbstractProvider.php",
+		"{$kontrol_filesystem_root}/Provider/SystemProvider.php",
+		"{$kontrol_filesystem_root}/Filesystems.php",
+	);
+
+	foreach ($kontrol_filesystem_fallbacks as $file) {
+		if (file_exists($file)) {
+			require_once($file);
+		}
+	}
+}
+
 use Kontrol\Services\Filesystem\{
 	Filesystem,
 	Filesystems,


### PR DESCRIPTION
### Motivation
- Corrige o erro "Class \"Kontrol\Services\Filesystem\Filesystems\" not found" que ocorre ao atualizar de versões antigas onde o autoload do Kontrol não está presente. 
- O problema acontece apenas em upgrades porque a árvore `/usr/local/Kontrol/include/vendor/autoload.php` ou os arquivos do `composer` podem não ser incluídos no `base.txz`, deixando o widget `disk` sem as classes necessárias.

### Description
- Adiciona um `class_exists` check e carrega manualmente os ficheiros das classes do Filesystem como fallback quando `Kontrol` autoloader não está disponível. 
- Os ficheiros carregados por fallback são `Filesystem.php`, `Provider/AbstractProvider.php`, `Provider/SystemProvider.php` e `Filesystems.php` a partir de `'/usr/local/Kontrol/include/Services/Filesystem'`, e a alteração foi feita em `src/usr/local/www/widgets/include/disks.inc`.

### Testing
- Nenhum teste automatizado foi executado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e3954afc0832eaed0dba5b93f88ac)