### PR TITLE
Force OpenSSL 1.1.1 for www/e2guardian54 builds

### DIFF
--- a/tools/conf/pfPorts/make.conf
+++ b/tools/conf/pfPorts/make.conf
@@ -22,6 +22,10 @@ ETCDIR=	/var/etc/frr
 .endif
 
 DEFAULT_VERSIONS=	go=1.23 php=8.3 python=3.11 ssl=base
+
+.if ${.CURDIR:N*www/e2guardian54*}==""
+DEFAULT_VERSIONS+=	ssl=openssl111
+.endif
 PHP_FD_SETSIZE=		3172
 
 . if ${.CURDIR:N*sysutils/check_reload_status*}==""


### PR DESCRIPTION
### Motivation
- Ensure the `www/e2guardian54` port is built with `ssl=openssl111` (matching its Makefile or port requirements) without changing the global `ssl=base` default for other ports.

### Description
- Add a conditional in `tools/conf/pfPorts/make.conf` that appends `DEFAULT_VERSIONS+= ssl=openssl111` when `.CURDIR` matches `www/e2guardian54`, leaving the rest of the system using `ssl=base`.

### Testing
- No automated tests were run because this is a configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970ee0490b0832e9639cba2e03f348c)