### PR TITLE
Pass and use subrule number for firewall log rule lookups and display

### DIFF
--- a/src/etc/inc/syslog.inc
+++ b/src/etc/inc/syslog.inc
@@ -1330,11 +1330,12 @@ function get_port_with_service($port, $proto) {
 	return ':' . $portstr;
 }
 
-function find_rule_by_number($rulenum, $trackernum, $type="block") {
+function find_rule_by_number($rulenr, $subrulenr, $trackernum, $type="block") {
 	$result = [
 		'match' => null,
 		'associated' => null
 	];
+	$rulenum = (is_numericint($subrulenr) ? $subrulenr : $rulenr);
 
 	/* Passing arbitrary input to grep could be a Very Bad Thing(tm) */
 	if (!is_numeric($rulenum) || !is_numeric($trackernum)) {
@@ -1462,8 +1463,10 @@ function buffer_rules_clear() {
 	unset($GLOBALS['buffer_rules_rdr']);
 }
 
-function find_rule_by_number_buffer($rulenum, $trackernum, $type) {
+function find_rule_by_number_buffer($rulenr, $subrulenr, $trackernum, $type) {
 	global $g, $buffer_rules_rdr, $buffer_rules_normal;
+
+	$rulenum = (is_numericint($subrulenr) ? $subrulenr : $rulenr);
 
 	if ($trackernum == "0") {
 		$lookup_key = "@{$rulenum}";
@@ -1544,7 +1547,7 @@ function handle_ajax() {
 					$icon_act = "fa-solid fa-check text-success";
 				}
 
-				$btn = '<i class="' . $icon_act . ' icon-pointer" title="' . $log_row['act'] . '/' . $log_row['reason'] .'/'. $log_row['tracker'] . '" onclick="javascript:getURL(\'status_logs_filter.php?getrulenum=' . $log_row['rulenum'] . ',' . $log_row['tracker'] . ',' . $log_row['act'] . '\', outputrule);"></i>';
+				$btn = '<i class="' . $icon_act . ' icon-pointer" title="' . $log_row['act'] . '/' . $log_row['reason'] .'/'. $log_row['tracker'] . '" onclick="javascript:getURL(\'status_logs_filter.php?getrulenum=' . $log_row['rulenum'] . ',' . $log_row['subrulenum'] . ',' . $log_row['tracker'] . ',' . $log_row['act'] . '\', outputrule);"></i>';
 				$new_rules .= "{$btn}||{$log_row['time']}||{$log_row['interface']}||{$log_row['srcip']}||{$log_row['srcport']}||{$log_row['dstip']}||{$log_row['dstport']}||{$log_row['proto']}||{$log_row['version']}||" . time() . "||\n";
 			}
 		}
@@ -1573,7 +1576,7 @@ function print_syslog_rule_action($rule) {
 			break;
 	}
 
-	$rules = find_rule_by_number($rule['rulenum'], $rule['tracker'], $action);
+	$rules = find_rule_by_number($rule['rulenum'], $rule['subrulenum'], $rule['tracker'], $action);
 	if (isset($rules['match']) && ($action == 'block') && preg_match('/^@\d+ block return /', $rules['match'])) {
 		// "reject" action is not supported - filterlog writes it as 'block' - check the rule itself.
 		$action = 'reject';

--- a/src/usr/local/www/status_logs_filter.php
+++ b/src/usr/local/www/status_logs_filter.php
@@ -83,8 +83,8 @@ if ($view == 'summary') { $view_title = gettext("Summary View"); }
 $rulenum = getGETPOSTsettingvalue('getrulenum', null);
 
 if ($rulenum) {
-	list($rulenum, $tracker, $type) = explode(',', $rulenum);
-	$rule = find_rule_by_number($rulenum, $tracker, $type);
+	list($rulenum, $subrulenum, $tracker, $type) = explode(',', $rulenum);
+	$rule = find_rule_by_number($rulenum, $subrulenum, $tracker, $type);
 	$rule = $rule['match'] ?? 'unavailable';
 	echo gettext("The rule that triggered this action is") . ":\n\n{$rule}";
 	exit;
@@ -199,7 +199,7 @@ if (!$rawfilter) {
 		if ($filterdescriptions === "1") {
 ?>
 					<td style="white-space:normal;">
-			<?=find_rule_by_number_buffer($filterent['rulenum'], $filterent['tracker'], $filterent['act'])?>
+			<?=find_rule_by_number_buffer($filterent['rulenum'], $filterent['subrulenum'], $filterent['tracker'], $filterent['act'])?>
 					</td>
 <?php
 		}
@@ -267,7 +267,7 @@ if (!$rawfilter) {
 ?>
 				<tr>
 					<td colspan="2" />
-					<td colspan="4"><?=find_rule_by_number_buffer($filterent['rulenum'], $filterent['tracker'], $filterent['act'])?></td>
+					<td colspan="4"><?=find_rule_by_number_buffer($filterent['rulenum'], $filterent['subrulenum'], $filterent['tracker'], $filterent['act'])?></td>
 				</tr>
 <?php
 		}

--- a/src/usr/local/www/status_logs_filter_dynamic.php
+++ b/src/usr/local/www/status_logs_filter_dynamic.php
@@ -432,7 +432,7 @@ function toggleListDescriptions() {
 								$icon_act = "fa-solid fa-check text-success";
 							}
 ?>
-							<i class="<?=$icon_act;?> icon-pointer" title="<?php echo $filterent['act'] .'/'. $filterent['reason'] .'/'. $filterent['tracker'];?>" onclick="javascript:getURL('status_logs_filter.php?getrulenum=<?="{$filterent['rulenum']},{$filterent['tracker']},{$filterent['act']}"; ?>', outputrule);"></i>
+							<i class="<?=$icon_act;?> icon-pointer" title="<?php echo $filterent['act'] .'/'. $filterent['reason'] .'/'. $filterent['tracker'];?>" onclick="javascript:getURL('status_logs_filter.php?getrulenum=<?="{$filterent['rulenum']},{$filterent['subrulenum']},{$filterent['tracker']},{$filterent['act']}"; ?>', outputrule);"></i>
 						</td>
 						<td><?=htmlspecialchars($filterent['time'])?></td>
 						<td><?=htmlspecialchars($filterent['interface'])?></td>

--- a/src/usr/local/www/widgets/widgets/log.widget.php
+++ b/src/usr/local/www/widgets/widgets/log.widget.php
@@ -280,8 +280,9 @@ if (!$_REQUEST['ajax']) {
 //DEBUG:		$date1 = new DateTime($date);
 
 		$rule = "no rule info available";
+		$filterent_rule_number = (is_numericint($filterent['subrulenum']) ? $filterent['subrulenum'] : $filterent['rulenum']);
 		foreach ($rulekeys as $actrule):
-			if ($actrule['rulenum'] == $filterent['rulenum']) {
+			if ($actrule['rulenum'] == $filterent_rule_number) {
 				$rawidx = $actrule['rawidx'];
 				$rule = $rule_lines[$rawidx];
 			break;
@@ -302,6 +303,7 @@ if (!$_REQUEST['ajax']) {
 
 	$resultarray[] = array(
 		'rulenum' => $filterent['rulenum'],
+		'subrulenum' => $filterent['subrulenum'],
 		'tracker' => $filterent['tracker'],
 		'act' => $filterent['act'],
 		'iconfn' => $iconfn,
@@ -332,7 +334,7 @@ if (!$_REQUEST['ajax']) {
 ?>
 
 		<tr>
-			<td><i class="<?=$resultent['iconfn']?>" style="cursor: pointer;" onclick="javascript:getURL('status_logs_filter.php?getrulenum=<?php echo "{$resultent['rulenum']},{$resultent['tracker']},{$resultent['act']}"; ?>', outputrule);"
+			<td><i class="<?=$resultent['iconfn']?>" style="cursor: pointer;" onclick="javascript:getURL('status_logs_filter.php?getrulenum=<?php echo "{$resultent['rulenum']},{$resultent['subrulenum']},{$resultent['tracker']},{$resultent['act']}"; ?>', outputrule);"
 			title="<?=gettext("Rule that triggered this action: ") . htmlspecialchars($resultent['rule'])?>">
 			</a></td>
 			<td title="<?=htmlspecialchars($resultent['time'])?>"><?=htmlspecialchars($resultent['time'])?></td>


### PR DESCRIPTION
### Motivation
- Ensure accurate mapping of logged firewall events to the exact rule variant by passing the per-entry sub-rule number (subrulenum) through lookup paths so subrules generated by PF/miniupnpd are resolved correctly.

### Description
- Change signature of `find_rule_by_number` and `find_rule_by_number_buffer` to accept a `subrulenum` parameter and compute the effective rule number using `is_numericint($subrulenum)` when present.
- Propagate the `subrulenum` through all call sites by updating `status_logs_filter.php`, `status_logs_filter_dynamic.php`, `widgets/log.widget.php`, and the AJAX rule request construction to include the sub-rule field in `getrulenum` URLs.
- In the widget, add `subrulenum` to the per-entry result array and use it when matching against `rulekeys` to pick the correct rule line.
- Keep existing behavior when `subrulenum` is not numeric by falling back to the original `rulenum` value.

### Testing
- Ran `php -l` syntax checks on the modified PHP files and they passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc3c0f35ec832ea76903b44260a037)