### PR TITLE
Bump default Python version to 3.12 in pfPorts make.conf

### DIFF
--- a/tools/conf/pfPorts/make.conf
+++ b/tools/conf/pfPorts/make.conf
@@ -21,7 +21,7 @@ WITH_DEBUG=yes
 ETCDIR=	/var/etc/frr
 .endif
 
-DEFAULT_VERSIONS=	go=1.25 php=8.5 python=3.11 ssl=base
+DEFAULT_VERSIONS=	go=1.25 php=8.5 python=3.12 ssl=base
 PHP_FD_SETSIZE=		3172
 
 . if ${.CURDIR:N*sysutils/check_reload_status*}==""


### PR DESCRIPTION
### Motivation
- Update default Python version used for pfPorts packages to `3.12` to track a newer Python release.

### Description
- Modified `tools/conf/pfPorts/make.conf` to change `DEFAULT_VERSIONS` Python entry from `python=3.11` to `python=3.12`.

### Testing
- No automated tests were run for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a638f2c98dc832eac60e0bac3929e10)