### PR TITLE
Add pkg plist keyword support, sanitize pkg.conf, and improve repo/link handling

### DIFF
--- a/build/scripts/create_core_pkg.sh
+++ b/build/scripts/create_core_pkg.sh
@@ -45,6 +45,7 @@ Options:
 	-d destdir   -- Destination directory to create package
 	-a ABI       -- Package ABI
 	-A ALTABI    -- Package ALTABI (aka arch)
+	-k keywords  -- Directory containing custom pkg plist keywords
 	-h           -- Show this help and exit
 
 Environment:
@@ -55,7 +56,7 @@ END
 	exit 1
 }
 
-while getopts s:t:f:v:r:F:d:ha:A: opt; do
+while getopts s:t:f:v:r:F:d:ha:A:k: opt; do
 	case "$opt" in
 		t)
 			template=$OPTARG
@@ -84,6 +85,9 @@ while getopts s:t:f:v:r:F:d:ha:A: opt; do
 		A)
 			ALTABI=$OPTARG
 			;;
+		k)
+			keywords_dir=$OPTARG
+			;;
 		*)
 			usage
 			;;
@@ -101,6 +105,9 @@ done
 
 [ -e $destdir -a ! -d $destdir ] \
 	&& err "destination path already exists and is not a directory"
+
+[ -n "${keywords_dir}" -a ! -d "${keywords_dir}" ] \
+	&& err "pkg keyword path is not a directory"
 
 : ${TMPDIR=/tmp}
 : ${PRODUCT_NAME=Kontrol}
@@ -193,8 +200,14 @@ fi
 [ -n "${ALTABI}" ] \
     && echo "arch: ${ALTABI}" >> ${manifest}
 
+if [ -n "${keywords_dir}" ]; then
+	_pkg_create="env PLIST_KEYWORDS_DIR=${keywords_dir} pkg create"
+else
+	_pkg_create="pkg create"
+fi
+
 run "Creating core package ${template_name}" \
-	"pkg create -o ${destdir} -p ${plist} -r ${root} -m ${metadir}"
+	"${_pkg_create} -o ${destdir} -p ${plist} -r ${root} -m ${metadir}"
 
 force_rm ${scratchdir}
 trap "-" 1 2 15 EXIT

--- a/tools/builder_common.sh
+++ b/tools/builder_common.sh
@@ -70,8 +70,12 @@ core_pkg_create_repo() {
 	ln -sf .latest/All ${CORE_PKG_ALL_PATH}
 	#ln -sf .latest/digests.txz ${CORE_PKG_PATH}/digests.txz
 	ln -sf .latest/meta.conf ${CORE_PKG_PATH}/meta.conf
-	ln -sf .latest/meta.txz ${CORE_PKG_PATH}/meta.txz
-	ln -sf .latest/packagesite.txz ${CORE_PKG_PATH}/packagesite.txz
+	for _ext in tzst txz; do
+		[ -f "${CORE_PKG_REAL_PATH}/meta.${_ext}" ] \
+			&& ln -sf ".latest/meta.${_ext}" "${CORE_PKG_PATH}/meta.${_ext}"
+		[ -f "${CORE_PKG_REAL_PATH}/packagesite.${_ext}" ] \
+			&& ln -sf ".latest/packagesite.${_ext}" "${CORE_PKG_PATH}/packagesite.${_ext}"
+	done
 }
 
 # Create core pkg (base, kernel)
@@ -102,6 +106,7 @@ core_pkg_create() {
 		-d "${CORE_PKG_REAL_PATH}/All" \
 		-a "${_abi}" \
 		-A "${_altabi}" \
+		-k "${BUILDER_TOOLS}/templates/pkg_keywords" \
 		|| print_error_pfS
 }
 
@@ -661,6 +666,7 @@ clone_to_staging_area() {
 
 	# Make sure pkg is present
 	pkg_bootstrap ${STAGE_CHROOT_DIR}
+	sanitize_pkg_conf ${STAGE_CHROOT_DIR} ${TARGET_ARCH}
 
 	# Make sure correct repo is available on tmp dir
 	mkdir -p ${STAGE_CHROOT_DIR}/tmp/pkg/pkg-repos
@@ -745,6 +751,14 @@ customize_stagearea_for_image() {
 			local _tgt_server="${PKG_REPO_SERVER_DEVEL}"
 		fi
 		for _db in ${FINAL_CHROOT_DIR}/var/db/pkg/repo-*sqlite; do
+			if [ ! -f "${_db}" ]; then
+				continue
+			fi
+			if ! /usr/local/bin/sqlite3 "${_db}" \
+				"select name from sqlite_master where type='table' and name='repodata'" \
+				| grep -q '^repodata$'; then
+				continue
+			fi
 			_cur=$(/usr/local/bin/sqlite3 ${_db} "${_read_cmd}")
 			_new=$(echo "${_cur}" | sed -e "s,^${PKG_REPO_SERVER_STAGING},${_tgt_server},")
 			/usr/local/bin/sqlite3 ${_db} "update repodata set value='${_new}' where key='packagesite'"
@@ -999,6 +1013,46 @@ get_altabi_arch() {
 	fi
 }
 
+get_osversion() {
+	local _osversion=""
+
+	if [ -n "${FREEBSD_SRC_DIR}" -a -f "${FREEBSD_SRC_DIR}/sys/sys/param.h" ]; then
+		_osversion=$(awk '/^#define[[:space:]]+__FreeBSD_version/ {print $3; exit}' \
+		    ${FREEBSD_SRC_DIR}/sys/sys/param.h)
+	fi
+
+	if [ -z "${_osversion}" ]; then
+		_osversion=$(sysctl -n kern.osreldate 2>/dev/null)
+	fi
+
+	if [ -z "${_osversion}" ]; then
+		_osversion=$(uname -K 2>/dev/null)
+	fi
+
+	echo "${_osversion}"
+}
+
+sanitize_pkg_conf() {
+	local _root="${1}"
+	local _target_arch="${2}"
+	local _pkg_conf="${_root}/usr/local/etc/pkg.conf"
+	local _abi=""
+	local _osversion=""
+
+	if [ ! -f "${_pkg_conf}" ]; then
+		return
+	fi
+
+	_abi=$(sed -e "s/%%ARCH%%/${_target_arch}/g" \
+	    ${PKG_REPO_DEFAULT%%.conf}.abi)
+	_osversion=$(get_osversion)
+
+	sed -i '' -e '/^ALTABI=/d' -e '/^ABI=/d' -e '/^OSVERSION=/d' ${_pkg_conf}
+
+	[ -n "${_abi}" ] && echo "ABI=${_abi}" >> ${_pkg_conf}
+	[ -n "${_osversion}" ] && echo "OSVERSION=${_osversion}" >> ${_pkg_conf}
+}
+
 # Create pkg conf on desired place with desired arch/branch
 setup_pkg_repo() {
 	if [ -z "${4}" ]; then
@@ -1014,6 +1068,8 @@ setup_pkg_repo() {
 	local _mirror_type="none"
 	local MIRROR_TYPE="none"
 	local _signature_type="fingerprints"
+	local _abi=""
+	local _osversion=""
 
 	if [ -z "${_template}" -o ! -f "${_template}" ]; then
 		echo ">>> ERROR: It was not possible to find pkg conf template ${_template}"
@@ -1048,17 +1104,14 @@ setup_pkg_repo() {
 		${_template} \
 		> ${_target}
 
-	local ALTABI_ARCH=$(get_altabi_arch ${_target_arch})
-
-	ABI=$(cat ${_template%%.conf}.abi 2>/dev/null \
+	_abi=$(cat ${_template%%.conf}.abi 2>/dev/null \
 	    | sed -e "s/%%ARCH%%/${_target_arch}/g")
-	ALTABI=$(cat ${_template%%.conf}.altabi 2>/dev/null \
-	    | sed -e "s/%%ARCH%%/${ALTABI_ARCH}/g")
+	_osversion=$(get_osversion)
 
-	if [ -n "${_pkg_conf}" -a -n "${ABI}" -a -n "${ALTABI}" ]; then
+	if [ -n "${_pkg_conf}" -a -n "${_abi}" -a -n "${_osversion}" ]; then
 		mkdir -p $(dirname ${_pkg_conf})
-		echo "ABI=${ABI}" > ${_pkg_conf}
-		echo "ALTABI=${ALTABI}" >> ${_pkg_conf}
+		echo "ABI=${_abi}" > ${_pkg_conf}
+		echo "OSVERSION=${_osversion}" >> ${_pkg_conf}
 	fi
 }
 

--- a/tools/conf/pfPorts/make.conf
+++ b/tools/conf/pfPorts/make.conf
@@ -21,7 +21,7 @@ WITH_DEBUG=yes
 ETCDIR=	/var/etc/frr
 .endif
 
-DEFAULT_VERSIONS=	go=1.25 php=8.5 python=3.11 ssl=base
+DEFAULT_VERSIONS=	go=1.25 php=8.5 python=3.12 ssl=base
 PHP_FD_SETSIZE=		3172
 
 . if ${.CURDIR:N*sysutils/check_reload_status*}==""

--- a/tools/templates/pkg_keywords/shell.ucl
+++ b/tools/templates/pkg_keywords/shell.ucl
@@ -1,0 +1,43 @@
+# MAINTAINER: portmgr@FreeBSD.org
+#
+# @shell bin/shell
+#
+# Handle adding and removing a shell binary path in /etc/shells.
+
+actions: [file]
+post-install-lua: <<EOD
+  shell_path = pkg.prefixed_path("%@")
+  shell = assert(io.open("/etc/shells", "r+"))
+  while true do
+    line = shell:read()
+    if line == nil then break end
+    if line == shell_path then
+      shell:close()
+      return
+    end
+  end
+  assert(shell:write(shell_path .. "\n"))
+  assert(shell:close())
+EOD
+pre-deinstall-lua: <<EOD
+  shell_path = pkg.prefixed_path("%@")
+  shellsbuf = ""
+  shells_path = "/etc/shells"
+  shell = assert(io.open(shells_path, "r+"))
+  found = false
+  while true do
+    line = shell:read()
+    if line == nil then break end
+    if line == shell_path then
+      found = true
+    else
+      shellsbuf = shellsbuf .. line .. "\n"
+    end
+  end
+  assert(shell:close())
+  if found then
+    shell = assert(io.open(shells_path, "w+"))
+    assert(shell:write(shellsbuf))
+    assert(shell:close())
+  end
+EOD


### PR DESCRIPTION
### Motivation

- Enable using custom pkg plist keywords during package creation and ensure generated pkg configuration in chroots contains correct ABI and OSVERSION values, while making pkg repo metadata linking robust to multiple compression extensions.

### Description

- Add a `-k`/`keywords_dir` option to `build/scripts/create_core_pkg.sh` and export `PLIST_KEYWORDS_DIR` when invoking `pkg create` so custom plist keywords (from `tools/templates/pkg_keywords`) are applied.
- Pass the keywords template directory from `tools/builder_common.sh` to `create_core_pkg.sh` and add a new `tools/templates/pkg_keywords/shell.ucl` keyword file to handle `/etc/shells` updates for shell packages.
- Make repository symlink creation tolerant to both `.tzst` and `.txz` metadata files instead of hardcoding extensions, by iterating `_ext in tzst txz` when creating `meta.*` and `packagesite.*` links.
- Add `get_osversion()` and `sanitize_pkg_conf()` in `tools/builder_common.sh` to populate `ABI` and `OSVERSION` into generated `pkg.conf` files and update `setup_pkg_repo()` to write `OSVERSION` (instead of `ALTABI`) using the detected OS version; also sanitize pkg conf in staging chroots after bootstrapping pkg.
- Bump default Python version in `tools/conf/pfPorts/make.conf` from `python=3.11` to `python=3.12`.

### Testing

- Performed static shell syntax checks with `bash -n` on the modified scripts which passed.
- No automated unit tests were added for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a638f2c98dc832eac60e0bac3929e10)