### PR TITLE
Enforce direct package repository access without DNS SRV

### DIFF
--- a/tools/builder_common.sh
+++ b/tools/builder_common.sh
@@ -1065,8 +1065,6 @@ setup_pkg_repo() {
 	local _target_arch="${4}"
 	local _staging="${5}"
 	local _pkg_conf="${6}"
-	local _mirror_type="none"
-	local MIRROR_TYPE="none"
 	local _signature_type="fingerprints"
 	local _abi=""
 	local _osversion=""
@@ -1090,9 +1088,13 @@ setup_pkg_repo() {
 
 	mkdir -p $(dirname ${_target}) >/dev/null 2>&1
 
+	# Kontrol repositories are direct HTTP endpoints.  Enforce this in the
+	# generated configuration as well as in the templates so pkg never falls
+	# back to DNS SRV discovery when a custom/older template is supplied.
 	sed \
 		-e "s/%%ARCH%%/${_target_arch}/" \
-		-e "s/%%MIRROR_TYPE%%/${_mirror_type}/" \
+		-e "s/%%MIRROR_TYPE%%/none/" \
+		-e '/mirror_type:/ s/"[^"]*"/"none"/' \
 		-e "s/%%PKG_REPO_BRANCH_DEVEL%%/${_pkg_repo_branch_devel}/g" \
 		-e "s/%%PKG_REPO_BRANCH_RELEASE%%/${_pkg_repo_branch_release}/g" \
 		-e "s,%%PKG_REPO_SERVER_DEVEL%%,${_pkg_repo_server_devel},g" \


### PR DESCRIPTION
### Motivation
- Prevent the package system from falling back to DNS SRV discovery for Kontrol repositories by ensuring generated repo configs always use direct HTTP mirrors.
- Close the remaining path where older or custom repository templates could re-enable SRV by normalizing the repository generation step.

### Description
- Removed redundant mirror variables `_mirror_type` and `MIRROR_TYPE` from `setup_pkg_repo()` in `tools/builder_common.sh`.
- Force `mirror_type` to `"none"` when rendering templates by replacing `%%MIRROR_TYPE%%` with `none` and normalizing any existing `mirror_type:` entries using `sed` in `setup_pkg_repo()`.
- Added a clarifying comment above the `sed` invocation explaining Kontrol repositories are direct HTTP endpoints and must not fall back to SRV.
- Note that repository templates under `tools/templates/pkg_repos/` were already updated to declare `mirror_type: "none"`, and this change enforces that at build time.

### Testing
- Successfully ran `sh -n tools/builder_common.sh` to validate shell syntax.
- Ran `git diff --check` with no warnings reported.
- Verified all repo templates with `for f in tools/templates/pkg_repos/*.conf; do awk '/mirror_type:/ && $0 !~ /"none"/ { bad=1 } END { exit bad }' "$f"; done` and confirmed all `mirror_type` values are `"none"`.
- Performed `curl` checks against the external repo URL which returned HTTP `503` via the environment proxy and failed to connect directly, indicating external endpoint availability issues unrelated to this code change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a653fdc36d4832e8917ad2a1f32e9d5)