### PR TITLE
Fix admin password update in setup wizard

### DIFF
--- a/src/usr/local/www/wizards/setup_wizard.xml
+++ b/src/usr/local/www/wizards/setup_wizard.xml
@@ -723,18 +723,25 @@
 	global $input_errors, $stepid, $savemsg;
 	$input_errors = [];
 	if (!empty($_POST['newadminpassword']) &&
-	    ($_POST['newadminpassword'] == $_POST['confirmadminpassword'])) {
-		$user_item_config = getUserEntryByUID(0);
+	    ($_POST['newadminpassword'] != $_POST['confirmadminpassword'])) {
+		$input_errors[] = gettext("New and Confirm Passwords do not match!");
+	}
+	if (!empty($_POST['newadminpassword'])) {
+		$admin_username = g_get('factory_shipped_username');
+		$user_item_config = getUserEntry($admin_username);
+		if (!is_array($user_item_config['item'])) {
+			$input_errors[] = gettext("Could not locate the admin account.");
+		} else {
+			$input_errors = array_merge($input_errors,
+			    validate_password($admin_username, $_POST['newadminpassword']));
+		}
+	}
+
+	if (!$input_errors && !empty($_POST['newadminpassword'])) {
 		$admin_user = &$user_item_config['item'];
 		local_user_set_password($user_item_config, $_POST['newadminpassword']);
 		local_user_set($admin_user);
 		write_config(gettext("Setup wizard changed admin account password."));
-	} elseif (!empty($_POST['newadminpassword']) &&
-		  ($_POST['newadminpassword'] != $_POST['confirmadminpassword'])) {
-		$input_errors[] = gettext("New and Confirm Passwords do not match!");
-	}
-	if (!empty($_POST['newadminpassword'])) {
-		$input_errors = array_merge($input_errors, validate_password('admin', $_POST['newadminpassword']));
 	}
 
 	if (count($input_errors) > 0) {


### PR DESCRIPTION
### Motivation

- The setup wizard previously assumed the admin account was always UID 0 and attempted to change its password without reliably locating the configured admin user, causing the password-change step to not persist after the wizard on some systems.
- The change ensures the wizard updates the actual configured administrative account and enforces the same password validation flow used elsewhere.

### Description

- Replace the UID-0 assumption by resolving the administrator account via the configured factory account name with `g_get('factory_shipped_username')` and `getUserEntry()` instead of `getUserEntryByUID(0)` in `src/usr/local/www/wizards/setup_wizard.xml` step 7. 
- Validate password confirmation first and then run `validate_password()` for the resolved admin username before applying changes. 
- Only call `local_user_set_password()` / `local_user_set()` and `write_config()` after all validations succeed, and add an error if the admin account cannot be located so the wizard remains on the password step.

### Testing

- `python3` script parsed the wizard XML and asserted the new admin lookup and validation ordering, and it passed. 
- Extracted step 7 PHP action and checked syntax with `php -l /tmp/setup-wizard-step7.php`, and `php -l src/usr/local/www/wizard.php`, both passed. 
- Ran `git diff --check` and repository status checks, which succeeded; `xmllint` was not available so XML was validated using Python's `xml.etree.ElementTree` and the checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a675f0b03a8832e9a675bbe7e8ffa1a)