### PR TITLE
Keep Hyper-V UEFI installer boot on the mounted ISO

### DIFF
--- a/tools/builder_common.sh
+++ b/tools/builder_common.sh
@@ -1214,6 +1214,32 @@ builder_setup() {
 }
 
 # Updates FreeBSD sources
+apply_freebsd_source_patches() {
+	local _patch_dir="${BUILDER_TOOLS}/patches/freebsd"
+	local _patch
+
+	[ -d "${_patch_dir}" ] || return 0
+
+	for _patch in "${_patch_dir}"/*.patch; do
+		[ -f "${_patch}" ] || continue
+		echo ">>> Applying FreeBSD source patch $(basename "${_patch}")..."
+		if patch -d "${FREEBSD_SRC_DIR}" -p0 -N --forward --silent \
+		    < "${_patch}"; then
+			continue
+		fi
+
+		# A source tree reused by the builder may already contain the patch.
+		if patch -d "${FREEBSD_SRC_DIR}" -p0 -R --dry-run --silent \
+		    < "${_patch}"; then
+			echo ">>> FreeBSD source patch $(basename "${_patch}") is already applied"
+			continue
+		fi
+
+		echo ">>> ERROR: Unable to apply FreeBSD source patch $(basename "${_patch}")"
+		print_error_pfS
+	done
+}
+
 update_freebsd_sources() {
 	if [ "${1}" = "full" ]; then
 		local _full=1
@@ -1245,6 +1271,8 @@ update_freebsd_sources() {
 			grep -C3 -i -E 'error|fatal'
 		echo "Done!"
 	fi
+
+	apply_freebsd_source_patches
 
 	if [ "${PRODUCT_NAME}" = "pfSense" -a -n "${GNID_REPO_BASE}" ]; then
 		echo ">>> Obtaining gnid sources..."

--- a/tools/patches/freebsd/stand-efi-loader-strict-boot-policy.patch
+++ b/tools/patches/freebsd/stand-efi-loader-strict-boot-policy.patch
@@ -1,0 +1,16 @@
+--- stand/efi/loader/main.c.orig
++++ stand/efi/loader/main.c
+@@ -146,7 +146,12 @@ EFI_LOADED_IMAGE *boot_img;
+ enum boot_policies {
+ 	STRICT,
+ 	RELAXED,
+-} boot_policy = RELAXED;
++} boot_policy = STRICT;
++
++/*
++ * Do not leave the boot device to probe an installed ZFS pool when loader.efi
++ * was started from removable media (for example, a Hyper-V Generation 2 DVD).
++ */
+ 
+ const char *policy_map[] = {
+ 	[STRICT] = "strict",


### PR DESCRIPTION
### Motivation

- FreeBSD 16's EFI loader defaulted to a `RELAXED` boot policy which probes and may select an installed ZFS pool when `loader.efi` is started from removable media, causing the ISO-booted loader to hand off to the installed system and appear as if the VM ignored the DVD boot order.
- Installer images produced by the builder could silently still behave this way unless the FreeBSD source tree used to build them is patched at build time.
- The builder lacked an automated, idempotent mechanism to apply local FreeBSD source patches after checkout, which is needed to ensure the ISO contains the intended boot behavior even when reusing a source tree.

### Description

- Add a FreeBSD source patch at `tools/patches/freebsd/stand-efi-loader-strict-boot-policy.patch` that changes the EFI loader's default `boot_policy` from `RELAXED` to `STRICT` and documents preventing probing away from the removable boot device.
- Add `apply_freebsd_source_patches()` to `tools/builder_common.sh` and call it from `update_freebsd_sources()` so local FreeBSD source patches are applied automatically after the repository checkout.
- Make patch application idempotent by detecting already-applied patches and by failing the build with a clear error if a patch cannot be applied cleanly to the checked-out source tree.

### Testing

- Ran a shell syntax check of the modified builder script with `sh -n tools/builder_common.sh` which succeeded.
- Verified patch application with `patch -d /tmp/freebsd-patch-test -p0 --dry-run < tools/patches/freebsd/stand-efi-loader-strict-boot-policy.patch`, a real apply to a downloaded `stand/efi/loader/main.c`, and a reverse dry-run, all of which succeeded.
- Performed `git diff --check` and local repository status checks to ensure no whitespace or patch issues remained, and those checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6770891960832eb1e8cab04feefb35)