### PR TITLE
Fix System Information update status check

### DIFF
--- a/src/usr/local/www/widgets/widgets/system_information.widget.php
+++ b/src/usr/local/www/widgets/widgets/system_information.widget.php
@@ -84,7 +84,12 @@ if ($_REQUEST['getupdatestatus']) {
 		exit;
 	}
 
-	$system_version = get_system_pkg_version(($_REQUEST['getupdatestatus'] == 1), false);
+	/*
+	 * Query the active repository.  The upgrade utility's portable check
+	 * interface is -c; checking alternative repositories requires -C, which
+	 * is not supported by every product's upgrade utility.
+	 */
+	$system_version = get_system_pkg_version(($_REQUEST['getupdatestatus'] == 1));
 
 	unset($error);
 	if (isset($system_version['pkg_version_error'])) {


### PR DESCRIPTION
### Motivation
- The System Information widget was invoking `get_system_pkg_version()` with an argument that caused the underlying upgrade utility to be called with `-C`, and some product upgrade utilities (e.g. `Kontrol-upgrade` on RELENG_2_9_0) do not implement `-C`, producing an unexpected exit code and the widget message "Unable to check for updates".

### Description
- Change the widget to call `get_system_pkg_version(($_REQUEST['getupdatestatus'] == 1))` so it queries the active repository using the portable `-c` check and avoid invoking `-C`, and add a short explanatory comment; no other logic was changed and the forced-refresh vs cached behavior is preserved.

### Testing
- Linted the widget with `php -l src/usr/local/www/widgets/widgets/system_information.widget.php` and it reported no syntax errors.
- Ran `git diff --check` and repository status checks to ensure no trailing issues, and these checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67826f6564832e9ea53601c81dae47)