### PR TITLE
Update default config to use dnsmasq, add DNS/webgui defaults; clear insecure_user session on admin password change

### DIFF
--- a/src/conf.default/config.xml
+++ b/src/conf.default/config.xml
@@ -8,6 +8,7 @@
 		<domain>home.arpa</domain>
 		<dnsserver></dnsserver>
 		<dnsallowoverride></dnsallowoverride>
+		<dnslocalhost>remote</dnslocalhost>
 		<group>
 			<name>all</name>
 			<description><![CDATA[All Users]]></description>
@@ -38,6 +39,7 @@
 		<webgui>
 			<protocol>https</protocol>
 			<loginautocomplete></loginautocomplete>
+			<webguifixedmenu>fixed</webguifixedmenu>
 		</webgui>
 		<disablenatreflection>yes</disablenatreflection>
 		<disablesegmentationoffloading></disablesegmentationoffloading>
@@ -266,16 +268,9 @@
 	</widgets>
 	<openvpn></openvpn>
 	<dnshaper></dnshaper>
-	<unbound>
+	<dnsmasq>
 		<enable></enable>
-		<dnssec></dnssec>
-		<active_interface></active_interface>
-		<outgoing_interface></outgoing_interface>
-		<custom_options></custom_options>
-		<hideidentity></hideidentity>
-		<hideversion></hideversion>
-		<dnssecstripped></dnssecstripped>
-	</unbound>
+	</dnsmasq>
 	<vlans>
 	</vlans>
 	<qinqs>

--- a/src/usr/local/www/wizards/setup_wizard.xml
+++ b/src/usr/local/www/wizards/setup_wizard.xml
@@ -728,6 +728,10 @@
 		$admin_user = &$user_item_config['item'];
 		local_user_set_password($user_item_config, $_POST['newadminpassword']);
 		local_user_set($admin_user);
+		/* invalidate the password security warning cache, see #16720 and #16728 */
+		phpsession_begin();
+		unset($_SESSION['insecure_user']);
+		phpsession_end(true);
 		write_config(gettext("Setup wizard changed admin account password."));
 	} elseif (!empty($_POST['newadminpassword']) &&
 		  ($_POST['newadminpassword'] != $_POST['confirmadminpassword'])) {


### PR DESCRIPTION
### Motivation
- Switch the default DNS backend from `unbound` to `dnsmasq` and add sensible defaults for localhost DNS behavior and the web GUI layout. 
- Ensure the insecure-password warning cache is cleared when the setup wizard changes the admin password (see `#16720` and `#16728`).

### Description
- Replaced the `<unbound>` section with a `<dnsmasq>` element in `src/conf.default/config.xml` and removed unused `unbound` child options such as `dnssec`, `active_interface`, `outgoing_interface`, `custom_options`, `hideidentity`, `hideversion`, and `dnssecstripped`.
- Added `<dnslocalhost>remote</dnslocalhost>` and `<webguifixedmenu>fixed</webguifixedmenu>` default entries to `src/conf.default/config.xml`.
- Updated `src/usr/local/www/wizards/setup_wizard.xml` to begin the PHP session, `unset($_SESSION['insecure_user'])`, and end the session after the admin password is changed to invalidate the insecure-password warning cache.

### Testing
- Ran `xmllint` (XML syntax validation) against the modified XML files and it succeeded.
- Ran PHP syntax check (`php -l`) on the modified wizard file and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a675f0b03a8832e9a675bbe7e8ffa1a)