### PR TITLE
Default amd64 Poudriere builds and RELENG_2_7_2 build documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,8 @@ Read more at [https://pfsense.org/](https://pfsense.org/ "The pfSense homepage")
 ## Contribute
 
 For information on how to contribute to the pfSense project, see [CONTRIBUTING](.github/CONTRIBUTING.md).
+
+## Building Kontrol RELENG_2_7_2
+
+See the [RELENG_2_7_2 build notes](docs/BUILD_RELENG_2_7_2.md) for the
+FreeBSD/PHP prerequisites and the reproducible Composer workflow.

--- a/build.conf.sample
+++ b/build.conf.sample
@@ -29,6 +29,14 @@ export PRODUCT_URL="https://PRODUCT_URL/"
 #export FREEBSD_BRANCH=stable/10
 #export GIT_FREEBSD_COSHA1=##HASH##
 
+# Kontrol Poudriere jails default to amd64 without lib32. Set this to NO only
+# if 32-bit compatibility libraries become a release requirement.
+#export POUDRIERE_WITHOUT_LIB32=YES
+
+# arm.armv7 remains available as an explicit override on a configured host,
+# but it is not built automatically.
+#export DEFAULT_ARCH_LIST="amd64.amd64"
+
 # Do not clean FreeBSD obj dirs
 #export NO_CLEAN_FREEBSD_OBJ=YES
 

--- a/docs/BUILD_RELENG_2_7_2.md
+++ b/docs/BUILD_RELENG_2_7_2.md
@@ -1,0 +1,207 @@
+# Building Kontrol RELENG_2_7_2
+
+These notes describe the host preparation needed before running `build.sh` on
+FreeBSD 14, with particular attention to preserving the dependency versions in
+`composer.lock`.
+
+## Composer prerequisites
+
+The PHP CLI used by Composer must provide the DOM, tokenizer, XML, XMLReader,
+and XMLWriter extensions required by the locked dependencies. FreeBSD packages
+these as separate PHP 8.2 modules, so install all of the corresponding binary
+packages:
+
+```sh
+pkg install php82-dom php82-tokenizer php82-xml php82-xmlreader php82-xmlwriter
+```
+
+Do not work around missing extensions with `--ignore-platform-req`. Doing so
+only skips Composer's host check; it does not make the extensions available to
+the installed application or its tools.
+
+Confirm that the CLI process is loading the expected PHP 8.2 configuration and
+modules:
+
+```sh
+php --version
+php --ini
+php -m | egrep -i '^(dom|tokenizer|xml|xmlreader|xmlwriter)$'
+```
+
+The last command must print all five module names (the check is
+case-insensitive because their displayed capitalization can vary).
+If a package is installed but its module is absent, inspect
+`/usr/local/etc/php/` and make sure Composer and `php --ini` resolve to the same
+PHP executable and configuration tree.
+
+The package repository configured on the build host must contain PHP 8.2
+packages. Check availability before changing repository configuration:
+
+```sh
+pkg search -x 'php82-(dom|tokenizer|xml|xmlreader|xmlwriter)'
+pkg info php82 php82-dom php82-tokenizer php82-xml php82-xmlreader php82-xmlwriter
+```
+
+Avoid mixing extensions from a different PHP minor version. If `pkg` proposes
+replacing `php82` with a newer PHP branch, fix or pin the repository used for
+the RELENG_2_7_2 build rather than accepting a mixed PHP installation.
+
+## Install the locked dependencies
+
+Use `install`, rather than `update`, for a reproducible release build:
+
+```sh
+cd /usr/Kontrol
+composer install --prefer-dist --no-interaction
+composer check-platform-reqs --lock
+```
+
+If Composer reports `ext-xmlreader` or `ext-xmlwriter` as missing after the
+first prerequisite installation, install the two separately packaged modules
+and retry the same locked install:
+
+```sh
+pkg install php82-xmlreader php82-xmlwriter
+php -m | egrep -i '^(xmlreader|xmlwriter)$'
+composer install --prefer-dist --no-interaction
+```
+
+This is another host prerequisite error, not evidence that the versions in the
+lock file are incompatible. Do not run `composer update` in response to it.
+
+`composer install` consumes the exact versions and references recorded in
+`composer.lock`. In contrast, `composer update` resolves the version ranges in
+`composer.json` again and can replace dependencies with releases that were not
+used for RELENG_2_7_2.
+
+Composer may warn that the lock file's content hash does not match
+`composer.json`. Treat that warning separately from the missing-extension
+error: do not run an unrestricted update merely to silence it. First use:
+
+```sh
+composer validate --no-check-publish
+git diff -- composer.json composer.lock
+```
+
+If a lock-file refresh is intentionally required, perform it in a dedicated
+change, review the complete `composer.lock` diff, and test the resulting build.
+Do not combine that dependency change with host bootstrap troubleshooting.
+
+## Build sequence
+
+After Composer completes successfully, the usual RELENG_2_7_2 sequence is:
+
+```sh
+cd /usr/Kontrol
+time ./build.sh --setup-poudriere
+./build.sh --update-poudriere-ports
+time ./build.sh --update-pkg-repo
+time ./build.sh --build-kernels
+time ./build.sh -i iso
+```
+
+The kernel-only step is optional as a diagnostic, but it is useful for
+separating base/kernel failures from ports and package failures. Save the full
+output of each step. When an old port fails, record the failing origin, package
+version, poudriere jail name, ports-tree revision, and the first actual compiler
+or fetch error rather than only the final `build failed` summary.
+
+## Poudriere fails building `aes-586.S`
+
+To delegate the corresponding source-tree work safely, use the prepared
+[Codex prompt for the FreeBSD-src repository](CODEX_PROMPT_FREEBSD_SRC_RELENG_2_7_2.md).
+
+The following failure is not caused by the preceding `libmd` or OpenZFS
+warnings:
+
+```text
+make[4]: don't know how to make aes-586.S. Stop
+*** [build32] Error code 2
+```
+
+The fatal error occurs while building the i386 compatibility libraries for an
+amd64 jail. On the `RELENG_2_7_2` FreeBSD source branch,
+`secure/lib/libcrypto/Makefile` includes `aes-586.S` in the i386 assembly
+sources, and its `.PATH` expects the generated file under
+`sys/crypto/openssl/i386`. If that file is absent, `make` cannot construct
+`libcrypto` and the later `buildworld` and jail errors are only consequences.
+
+### Confirm the source-tree inconsistency
+
+Check the remote branch independently of the temporary jail, because Poudriere
+removes the failed jail during cleanup:
+
+```sh
+git clone --depth 1 --branch RELENG_2_7_2 \
+  https://github.com/kontrol-br/FreeBSD-src.git /usr/FreeBSD-src-RELENG_2_7_2
+cd /usr/FreeBSD-src-RELENG_2_7_2
+grep -n 'aes-586.S' secure/lib/libcrypto/Makefile
+git ls-files sys/crypto/openssl/i386/aes-586.S
+test -f sys/crypto/openssl/i386/aes-586.S
+```
+
+The `grep` command finding a reference while the last two checks produce no
+file confirms the incomplete source tree. Re-running `--setup-poudriere`
+against the unchanged remote branch will reproduce the same failure.
+
+### Immediate release-compatible workaround
+
+The Kontrol source configuration already disables 32-bit compatibility
+libraries. The build scripts now tell Poudriere the same thing automatically
+by creating the jail-specific source configuration. After updating this
+repository, retry directly:
+
+```sh
+cd /usr/Kontrol
+git pull --ff-only
+time ./build.sh --setup-poudriere
+```
+
+For an older checkout without that build-script change, create the equivalent
+configuration manually before retrying:
+
+```sh
+mkdir -p /usr/local/etc/poudriere.d
+printf 'WITHOUT_LIB32=yes\n' \
+  > /usr/local/etc/poudriere.d/Kontrol_v2_7_2_amd64-src.conf
+cd /usr/Kontrol
+time ./build.sh --setup-poudriere
+```
+
+Poudriere reads a jail-specific `<jail>-src.conf` while running `buildworld`.
+Verify in the new log that it no longer enters `stage 4.3.1: building lib32
+shim libraries`. This workaround is appropriate only while the product remains
+configured with `WITHOUT_LIB32`; remove it if 32-bit ABI support becomes a
+release requirement.
+
+The scripts also default the Poudriere architecture list to `amd64.amd64`.
+Installing qemu-user-static no longer silently adds an ARM jail; `arm.armv7`
+remains available only through an explicit `ARCH_LIST` override on a properly
+configured development host.
+
+### Permanent source fix
+
+The source repository should still be made internally buildable. Generate the
+missing assembly from the OpenSSL sources already present on the same branch,
+rather than copying an arbitrary generated file from a different OpenSSL
+version:
+
+```sh
+cd /usr/FreeBSD-src-RELENG_2_7_2
+cd secure/lib/libcrypto
+make TARGET=i386 TARGET_ARCH=i386 -f Makefile.asm aes-586.S
+install -m 0644 aes-586.S ../../../sys/crypto/openssl/i386/aes-586.S
+rm -f aes-586.S
+cd ../../..
+git status --short
+git diff --check
+git add sys/crypto/openssl/i386/aes-586.S
+git commit -m 'libcrypto: restore generated i386 AES assembly'
+git push origin RELENG_2_7_2
+```
+
+Review the generated file and test `buildworld` before pushing. Once the fixed
+commit is visible on the remote branch, remove the failed Poudriere jail if it
+still exists and rerun `./build.sh --setup-poudriere`. Record the source commit
+used by the successful jail so future rebuilds do not silently move to a
+different branch tip.

--- a/docs/CODEX_PROMPT_FREEBSD_SRC_RELENG_2_7_2.md
+++ b/docs/CODEX_PROMPT_FREEBSD_SRC_RELENG_2_7_2.md
@@ -1,0 +1,135 @@
+# Codex prompt for FreeBSD-src RELENG_2_7_2
+
+Copy the prompt below into Codex while its working directory is the root of the
+`kontrol-br/FreeBSD-src` repository on branch `RELENG_2_7_2`.
+
+```text
+Estamos mantendo o repositório https://github.com/kontrol-br/FreeBSD-src.git,
+branch RELENG_2_7_2, usado como base do Kontrol 2.7.2 e para criar o jail do
+Poudriere.
+
+Objetivo
+========
+
+Prepare este branch exclusivamente para builds amd64 de 64 bits do Kontrol.
+Não construiremos imagens, kernels, world, bibliotecas de compatibilidade ou
+native-xtools para ARM, armv7, aarch64, i386 ou qualquer outro alvo de 32 bits.
+Faça uma correção mínima, auditável e compatível com os scripts de release e
+com o Poudriere. Não remova diretórios de arquitetura da árvore do FreeBSD e não
+faça uma limpeza ampla do código upstream: TARGET/TARGET_ARCH e as opções de
+src.conf devem selecionar amd64; apagar fontes compartilhadas ou de outras
+arquiteturas pode quebrar ferramentas de geração, targets do make e futuros
+merges.
+
+Problema observado
+==================
+
+Ao criar o jail amd64 com `poudriere jail -c ... -a amd64 -m git`, o buildworld
+entrou em `stage 4.3.1: building lib32 shim libraries` e falhou em:
+
+    make[4]: don't know how to make aes-586.S. Stop
+    *** [build32] Error code 2
+
+No branch atual, `secure/lib/libcrypto/Makefile` referencia `aes-586.S` quando
+`ASM_i386` está ativo, mas `sys/crypto/openssl/i386/aes-586.S` não está
+rastreado. Os warnings anteriores de libmd e OpenZFS não são a causa fatal.
+Também já existe `WITHOUT_LIB32=YES` em `release/conf/Kontrol_src.conf`, mas o
+log demonstra que a criação do jail não está usando efetivamente essa opção.
+
+Tarefas obrigatórias
+====================
+
+1. Leia todos os AGENTS.md aplicáveis antes de editar e examine o histórico
+   recente do branch.
+2. Confirme os fatos com comandos, incluindo:
+   - `git branch --show-current` e `git rev-parse HEAD`;
+   - busca por `WITHOUT_LIB32`, `WITH_LIB32`, `TARGET`, `TARGET_ARCH`,
+     `aes-586.S`, `ASM_i386` e pelas configurações Kontrol;
+   - `git ls-files sys/crypto/openssl/i386/aes-586.S`;
+   - inspeção de `release/conf/Kontrol_src.conf`, dos scripts de release e dos
+     Makefiles envolvidos.
+3. Identifique qual configuração deste repositório é realmente consumida pelos
+   builds do Kontrol. Preserve `TARGET=amd64` e `TARGET_ARCH=amd64` nos pontos
+   apropriados e garanta `WITHOUT_LIB32=yes` no src.conf efetivamente passado a
+   buildworld/installworld. Não invente flags de make: confirme cada knob na
+   infraestrutura `share/mk`, `tools/build/options` ou documentação presente na
+   própria árvore.
+4. Não confunda a configuração do release com a do Poudriere: o método git do
+   Poudriere normalmente monta seu próprio `<jail>-src.conf` a partir de
+   `/usr/local/etc/poudriere.d`. Se não houver como este repositório obrigar o
+   consumidor a usar `release/conf/Kontrol_src.conf`, documente claramente essa
+   fronteira e forneça o nome e conteúdo exatos do arquivo externo necessário:
+
+       /usr/local/etc/poudriere.d/Kontrol_v2_7_2_amd64-src.conf
+       WITHOUT_LIB32=yes
+
+   Não alegue que uma alteração no FreeBSD-src, sozinha, modifica o
+   comportamento do Poudriere se o arquivo não for lido por ele.
+5. Mantenha a árvore de fontes genérica. Não delete `sys/arm`, `sys/arm64`,
+   `sys/i386`, arquivos OpenSSL i386 ou listas de targets. Para este produto,
+   deixar de construir outros alvos é uma decisão de configuração, não uma
+   remoção de código upstream.
+6. Trate `aes-586.S` de uma destas formas, justificando a escolha:
+   - se todos os caminhos suportados passarem corretamente `WITHOUT_LIB32`,
+     confirme que o arquivo deixa de ser requisito para o build amd64 do
+     produto e não adicione um artefato não usado apenas para mascarar uma
+     configuração incorreta;
+   - se o branch deve continuar capaz de executar um buildworld FreeBSD padrão
+     com lib32, gere `aes-586.S` com o `Makefile.asm` e as fontes OpenSSL deste
+     mesmo commit, coloque-o em `sys/crypto/openssl/i386/`, revise o arquivo
+     gerado e o inclua em um commit separado. Não copie silenciosamente um
+     assembly de outra versão do OpenSSL.
+7. Procure nos scripts por loops/listas que disparem builds ARM ou 32-bit. Só os
+   altere se forem caminhos específicos do Kontrol e estiver comprovado que são
+   usados neste branch. Preserve defaults upstream e permita override explícito
+   sempre que possível.
+8. Adicione documentação curta, próxima da configuração alterada, explicando:
+   - que o release Kontrol é amd64-only;
+   - por que lib32 está desativado;
+   - qual configuração externa o Poudriere precisa consumir;
+   - como verificar que o build não entrou no target `build32`.
+
+Restrições
+==========
+
+- Não compile ARM, aarch64, armv7 ou i386.
+- Não execute um buildworld completo sem antes informar o custo e verificar os
+  recursos do ambiente.
+- Não use `WITHOUT_OPENSSL`, `WITHOUT_CRYPT` ou uma desativação ampla de
+  segurança como atalho.
+- Não desative warnings globalmente e não edite o OpenSSL para esconder o erro.
+- Não altere a ABI amd64 nem remova suporte necessário a ports amd64.
+- Não faça mudanças no repositório pfsense/Kontrol a partir deste checkout.
+- Não faça push forçado nem reescreva o histórico do branch.
+
+Validação mínima
+================
+
+Execute verificações rápidas e determinísticas antes de qualquer compilação
+longa:
+
+1. `git diff --check`.
+2. Mostre, por meio do make/configuração aplicável, que TARGET e TARGET_ARCH são
+   amd64 e que MK_LIB32/WITHOUT_LIB32 resulta em lib32 desativado.
+3. Faça um dry-run ou consulta de targets/variáveis que demonstre que `build32`
+   não será selecionado. Não considere apenas um grep no arquivo de configuração
+   como prova; confirme que o arquivo é efetivamente consumido.
+4. Rode os testes de sintaxe disponíveis para qualquer shell script alterado.
+5. Se gerar `aes-586.S`, demonstre que ele foi produzido das fontes OpenSSL do
+   branch atual e execute as verificações específicas do Makefile sem iniciar
+   builds de outras arquiteturas.
+6. Apresente `git status --short`, o diff final, riscos residuais e os comandos
+   exatos que o operador deverá executar no host FreeBSD/Poudriere.
+
+Entrega
+=======
+
+Implemente a solução, não apenas descreva sugestões. Faça commits pequenos com
+mensagens claras. No resumo final, separe explicitamente:
+
+- mudanças dentro do FreeBSD-src;
+- configuração externa exigida pelo Poudriere;
+- testes realmente executados;
+- testes não executados por limitação de ambiente;
+- hash do commit do FreeBSD-src que deverá ser fixado pelo processo de release.
+```

--- a/tools/builder_common.sh
+++ b/tools/builder_common.sh
@@ -1503,17 +1503,20 @@ pkg_repo_rsync() {
 poudriere_possible_archs() {
 	local _arch=$(uname -m)
 	local _archs=""
+	local _possible_archs=""
 
-	# If host is amd64, we'll create both repos, and if possible armv7
+	# Kontrol releases are amd64-only by default. Keep armv7 available only as
+	# an explicit ARCH_LIST override for developers with a configured emulator.
 	if [ "${_arch}" = "amd64" ]; then
 		_archs="amd64.amd64"
+		_possible_archs="${_archs}"
 
 		if [ -f /usr/local/bin/qemu-arm-static ]; then
 			# Make sure binmiscctl is ok
 			/usr/local/etc/rc.d/qemu_user_static forcestart >/dev/null 2>&1
 
 			if binmiscctl lookup armv7 >/dev/null 2>&1; then
-				_archs="${_archs} arm.armv7"
+				_possible_archs="${_possible_archs} arm.armv7"
 			fi
 		fi
 	fi
@@ -1522,7 +1525,7 @@ poudriere_possible_archs() {
 		local _found=0
 		for _desired_arch in ${ARCH_LIST}; do
 			_found=0
-			for _possible_arch in ${_archs}; do
+			for _possible_arch in ${_possible_archs}; do
 				if [ "${_desired_arch}" = "${_possible_arch}" ]; then
 					_found=1
 					break
@@ -1537,6 +1540,30 @@ poudriere_possible_archs() {
 	fi
 
 	echo ${_archs}
+}
+
+configure_poudriere_jail_srcconf() {
+	local _jail_arch="${1}"
+	local _jail_name="${2}"
+	local _srcconf="/usr/local/etc/poudriere.d/${_jail_name}-src.conf"
+
+	if [ "${_jail_arch}" != "amd64.amd64" ] || \
+	    [ "${POUDRIERE_WITHOUT_LIB32}" != "YES" ]; then
+		return 0
+	fi
+
+	if [ -f "${_srcconf}" ] && \
+	    grep -Eq '^[[:space:]]*WITH_LIB32([[:space:]]*=|[[:space:]]*$)' "${_srcconf}"; then
+		echo ">>> ERROR: ${_srcconf} enables WITH_LIB32, but POUDRIERE_WITHOUT_LIB32=YES"
+		print_error_pfS
+	fi
+
+	if [ ! -f "${_srcconf}" ] || \
+	    ! grep -Eq '^[[:space:]]*WITHOUT_LIB32([[:space:]]*=|[[:space:]]*$)' "${_srcconf}"; then
+		echo "WITHOUT_LIB32=yes" >> "${_srcconf}"
+	fi
+
+	echo ">>> Poudriere jail ${_jail_name} configured without lib32" | tee -a ${LOGFILE}
 }
 
 poudriere_jail_name() {
@@ -1833,6 +1860,7 @@ EOF
 	# Now we are ready to create jails
 	for jail_arch in ${_archs}; do
 		jail_name=$(poudriere_jail_name ${jail_arch})
+		configure_poudriere_jail_srcconf "${jail_arch}" "${jail_name}"
 
 		if [ "${jail_arch}" = "arm.armv7" ]; then
 			native_xtools="-x"

--- a/tools/builder_defaults.sh
+++ b/tools/builder_defaults.sh
@@ -122,6 +122,11 @@ export FREEBSD_REPO_BASE=${FREEBSD_REPO_BASE:-"${GIT_REPO_BASE}/Freebsd-src"}
 export FREEBSD_BRANCH=${FREEBSD_BRANCH:-"${REPO_BRANCH_PREFIX}RELENG_2_7_2"}
 export FREEBSD_SRC_DIR=${FREEBSD_SRC_DIR:-"${SCRATCHDIR}/FreeBSD-src"}
 
+# Kontrol release jails are amd64-only and do not need 32-bit compatibility
+# libraries. This can be overridden explicitly in build.conf if requirements
+# change in a future release.
+export POUDRIERE_WITHOUT_LIB32=${POUDRIERE_WITHOUT_LIB32:-"YES"}
+
 export BUILD_KERNELS=${BUILD_KERNELS:-"${PRODUCT_NAME}"}
 
 # XXX: Poudriere doesn't like ssh short form


### PR DESCRIPTION
### Motivation

- Prevent accidental 32-bit jail builds and the associated `aes-586.S` failure by ensuring Kontrol release builds default to amd64-only and Poudriere jails are configured without lib32. 
- Document the RELENG_2_7_2 host prerequisites and reproducible Composer-based workflow and provide an actionable Codex prompt to remediate FreeBSD-src issues when needed.

### Description

- Set the default `POUDRIERE_WITHOUT_LIB32=YES` and document the override in `build.conf.sample` and `tools/builder_defaults.sh` so Kontrol release jails are amd64-only by default. 
- Change the Poudriere arch selection logic in `tools/builder_common.sh` so the default arch list is `amd64.amd64` and `arm.armv7` is only considered when explicitly available and requested. 
- Add `configure_poudriere_jail_srcconf()` and call it before jail creation to create or append a jail-specific `/usr/local/etc/poudriere.d/<jail>-src.conf` with `WITHOUT_LIB32=yes` when appropriate. 
- Add comprehensive build documentation `docs/BUILD_RELENG_2_7_2.md` covering PHP/Composer prerequisites, reproducible `composer install` usage, build sequence, a workaround for the `aes-586.S` Poudriere failure, and guidance for generating a permanent source fix. 
- Add `docs/CODEX_PROMPT_FREEBSD_SRC_RELENG_2_7_2.md` containing a ready-to-use Codex prompt to prepare the FreeBSD-src `RELENG_2_7_2` branch for amd64-only builds. 
- Update `README.md` to reference the new RELENG_2_7_2 build notes.

### Testing

- Ran basic shell syntax checks with `bash -n` against the modified scripts and fixed detected issues, and `shellcheck` was used for static analysis with no actionable findings. 
- Executed the `poudriere_possible_archs` logic locally in a dry-run to confirm the returned arch list defaults to `amd64.amd64` and that `arm.armv7` is only added when qemu support is present, and the checks passed. 
- Performed a dry-run invocation of `configure_poudriere_jail_srcconf` to verify it creates the expected jail source config file containing `WITHOUT_LIB32=yes` when conditions are met, and the dry-run succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68cffd22dc832eace808dda0dc9d0c)