### PR TITLE
RELENG_2_7_2: separate safe current, previous, and upgrade repositories

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -278,7 +278,9 @@ if [ -n "${SNAPSHOTS}" -a -n "${UPLOAD}" ]; then
 		PKG_REPO_SERVER_RELEASE \
 		PKG_REPO_SERVER_STAGING \
 		PKG_REPO_BRANCH_DEVEL \
-		PKG_REPO_BRANCH_RELEASE"
+		PKG_REPO_BRANCH_RELEASE \
+		PKG_REPO_BRANCH_PREVIOUS \
+		PKG_REPO_BRANCH_UPGRADE"
 
 	for _var in ${_required}; do
 		eval "_value=\${$_var}"

--- a/tools/builder_common.sh
+++ b/tools/builder_common.sh
@@ -1032,6 +1032,12 @@ setup_pkg_repo() {
 		local _pkg_repo_branch_release=${PKG_REPO_BRANCH_RELEASE}
 	fi
 
+	# Previous and upgrade are explicit appliance choices, so their branch names
+	# always remain release branches. The server still follows the caller's
+	# staging mode, just like the current-release template.
+	local _pkg_repo_branch_previous=${PKG_REPO_BRANCH_PREVIOUS}
+	local _pkg_repo_branch_upgrade=${PKG_REPO_BRANCH_UPGRADE}
+
 	mkdir -p $(dirname ${_target}) >/dev/null 2>&1
 
 	sed \
@@ -1039,6 +1045,8 @@ setup_pkg_repo() {
 		-e "s/%%MIRROR_TYPE%%/${_mirror_type}/" \
 		-e "s/%%PKG_REPO_BRANCH_DEVEL%%/${_pkg_repo_branch_devel}/g" \
 		-e "s/%%PKG_REPO_BRANCH_RELEASE%%/${_pkg_repo_branch_release}/g" \
+		-e "s/%%PKG_REPO_BRANCH_PREVIOUS%%/${_pkg_repo_branch_previous}/g" \
+		-e "s/%%PKG_REPO_BRANCH_UPGRADE%%/${_pkg_repo_branch_upgrade}/g" \
 		-e "s,%%PKG_REPO_SERVER_DEVEL%%,${_pkg_repo_server_devel},g" \
 		-e "s,%%PKG_REPO_SERVER_RELEASE%%,${_pkg_repo_server_release},g" \
 		-e "s,%%POUDRIERE_PORTS_NAME%%,${POUDRIERE_PORTS_NAME},g" \
@@ -2068,6 +2076,8 @@ poudriere_bulk() {
 
 PKG_REPO_BRANCH_DEVEL=${PKG_REPO_BRANCH_DEVEL}
 PKG_REPO_BRANCH_RELEASE=${PKG_REPO_BRANCH_RELEASE}
+PKG_REPO_BRANCH_PREVIOUS=${PKG_REPO_BRANCH_PREVIOUS}
+PKG_REPO_BRANCH_UPGRADE=${PKG_REPO_BRANCH_UPGRADE}
 PKG_REPO_SERVER_DEVEL=${PKG_REPO_SERVER_DEVEL}
 PKG_REPO_SERVER_RELEASE=${PKG_REPO_SERVER_RELEASE}
 POUDRIERE_PORTS_NAME=${POUDRIERE_PORTS_NAME}
@@ -2110,8 +2120,26 @@ EOF
 			/usr/local/poudriere/ports/${POUDRIERE_PORTS_NAME}/sysutils/${PRODUCT_NAME}-repo/Makefile
 	fi
 
-	# Copy over pkg repo templates to pfSense-repo
-	mkdir -p /usr/local/poudriere/ports/${POUDRIERE_PORTS_NAME}/sysutils/${PRODUCT_NAME}-repo/files
+	# RELENG_2_7_2 ports understands the upgrade placeholder but predates the
+	# independent previous-branch placeholder. Teach the copied port to render it.
+	local _repo_makefile=/usr/local/poudriere/ports/${POUDRIERE_PORTS_NAME}/sysutils/${PRODUCT_NAME}-repo/Makefile
+	if ! grep -q '%%PKG_REPO_BRANCH_PREVIOUS%%' ${_repo_makefile}; then
+		sed -i '' \
+		    -e '/%%PKG_REPO_BRANCH_RELEASE%%/a\
+		-e "s,%%PKG_REPO_BRANCH_PREVIOUS%%,${PKG_REPO_BRANCH_PREVIOUS},g" \' \
+		    ${_repo_makefile}
+	fi
+
+	# Copy over pkg repo templates to pfSense-repo. Remove only generated repo
+	# metadata first so stale choices from an earlier build cannot survive, while
+	# preserving unrelated port files such as pkg-install and signing keys.
+	local _repo_files_dir=/usr/local/poudriere/ports/${POUDRIERE_PORTS_NAME}/sysutils/${PRODUCT_NAME}-repo/files
+	mkdir -p ${_repo_files_dir}
+	find ${_repo_files_dir} -maxdepth 1 -type f \
+	    \( -name "${PRODUCT_NAME}-repo*.conf" \
+	    -o -name "${PRODUCT_NAME}-repo*.descr" \
+	    -o -name "${PRODUCT_NAME}-repo*.abi" \
+	    -o -name "${PRODUCT_NAME}-repo*.altabi" \) -delete
 	cp -f ${PKG_REPO_BASE}/* \
 		/usr/local/poudriere/ports/${POUDRIERE_PORTS_NAME}/sysutils/${PRODUCT_NAME}-repo/files
 

--- a/tools/builder_defaults.sh
+++ b/tools/builder_defaults.sh
@@ -54,14 +54,11 @@ if [ -f ${BUILD_CONF} ]; then
 fi
 
 # Define pfSense versions
-PKG_REPO_BRANCH_DEVEL="devel"
-PKG_REPO_BRANCH_NEXT="v2_8_0"
-PKG_REPO_BRANCH_RELEASE="v2_7_2"
-PKG_REPO_BRANCH_PREVIOUS="v2_7_0"
 export PKG_REPO_BRANCH_DEVEL="devel"
 export PKG_REPO_BRANCH_NEXT="v2_8_0"
 export PKG_REPO_BRANCH_RELEASE="v2_7_2"
 export PKG_REPO_BRANCH_PREVIOUS="v2_7_0"
+export PKG_REPO_BRANCH_UPGRADE="v2_9_0"
 
 # Make sure pkg will not be interactive
 export ASSUME_ALWAYS_YES=true

--- a/tools/conf/pfPorts/make.conf
+++ b/tools/conf/pfPorts/make.conf
@@ -1,7 +1,7 @@
 ALLOW_UNSUPPORTED_SYSTEM=yes
 
 # Used by pfSense-upgrade port to set pkg_set_version
-PFSENSE_PKG_SET_VERSION=	Kontrol-repo Kontrol-repo-previous
+PFSENSE_PKG_SET_VERSION=	Kontrol-repo Kontrol-repo-previous Kontrol-repo-upgrade
 
 # Generic options
 OPTIONS_UNSET_FORCE=	DOCS DOXYGEN EXAMPLES INFO MAN MANPAGES X11

--- a/tools/templates/pkg_repos/Kontrol-repo-previous.altabi
+++ b/tools/templates/pkg_repos/Kontrol-repo-previous.altabi
@@ -1,1 +1,1 @@
-freeBSD:14:%%ARCH%%
+freebsd:14:%%ARCH%%

--- a/tools/templates/pkg_repos/Kontrol-repo-previous.descr
+++ b/tools/templates/pkg_repos/Kontrol-repo-previous.descr
@@ -1,1 +1,1 @@
-Previous stable version (2.7.2 DEPRECATED)
+Previous stable version (2.7.0)

--- a/tools/templates/pkg_repos/Kontrol-repo-upgrade.abi
+++ b/tools/templates/pkg_repos/Kontrol-repo-upgrade.abi
@@ -1,0 +1,1 @@
+FreeBSD:16:%%ARCH%%

--- a/tools/templates/pkg_repos/Kontrol-repo-upgrade.altabi
+++ b/tools/templates/pkg_repos/Kontrol-repo-upgrade.altabi
@@ -1,0 +1,1 @@
+freebsd:16:%%ARCH%%

--- a/tools/templates/pkg_repos/Kontrol-repo-upgrade.conf
+++ b/tools/templates/pkg_repos/Kontrol-repo-upgrade.conf
@@ -1,7 +1,7 @@
 FreeBSD: { enabled: no }
 
 %%PRODUCT_NAME%%-core: {
-  url: "%%PKG_REPO_SERVER_RELEASE%%/%%PRODUCT_NAME%%_%%PKG_REPO_BRANCH_PREVIOUS%%_%%ARCH%%-core",
+  url: "%%PKG_REPO_SERVER_RELEASE%%/%%PRODUCT_NAME%%_%%PKG_REPO_BRANCH_UPGRADE%%_%%ARCH%%-core",
   mirror_type: "none",
   signature_type: "%%SIGNATURE_TYPE%%",
   fingerprints: "/usr/local/share/%%PRODUCT_NAME%%/keys/pkg",
@@ -9,7 +9,7 @@ FreeBSD: { enabled: no }
 }
 
 %%PRODUCT_NAME%%: {
-  url: "%%PKG_REPO_SERVER_RELEASE%%/%%PRODUCT_NAME%%_%%PKG_REPO_BRANCH_PREVIOUS%%_%%ARCH%%-%%PRODUCT_NAME%%_%%PKG_REPO_BRANCH_PREVIOUS%%",
+  url: "%%PKG_REPO_SERVER_RELEASE%%/%%PRODUCT_NAME%%_%%PKG_REPO_BRANCH_UPGRADE%%_%%ARCH%%-%%PRODUCT_NAME%%_%%PKG_REPO_BRANCH_UPGRADE%%",
   mirror_type: "none",
   signature_type: "%%SIGNATURE_TYPE%%",
   fingerprints: "/usr/local/share/%%PRODUCT_NAME%%/keys/pkg",

--- a/tools/templates/pkg_repos/Kontrol-repo-upgrade.descr
+++ b/tools/templates/pkg_repos/Kontrol-repo-upgrade.descr
@@ -1,0 +1,1 @@
+Upgrade to 2.9.0 (FreeBSD 16)

--- a/tools/templates/pkg_repos/Kontrol-repo.abi
+++ b/tools/templates/pkg_repos/Kontrol-repo.abi
@@ -1,1 +1,1 @@
-FreeBSD:16:%%ARCH%%
+FreeBSD:14:%%ARCH%%

--- a/tools/templates/pkg_repos/Kontrol-repo.altabi
+++ b/tools/templates/pkg_repos/Kontrol-repo.altabi
@@ -1,1 +1,1 @@
-freeBSD:16:%%ARCH%%
+freebsd:14:%%ARCH%%

--- a/tools/templates/pkg_repos/Kontrol-repo.conf
+++ b/tools/templates/pkg_repos/Kontrol-repo.conf
@@ -1,7 +1,7 @@
 FreeBSD: { enabled: no }
 
 %%PRODUCT_NAME%%-core: {
-  url: "%%PKG_REPO_SERVER_RELEASE%%/%%PRODUCT_NAME%%_v2_9_0_%%ARCH%%-core",
+  url: "%%PKG_REPO_SERVER_RELEASE%%/%%PRODUCT_NAME%%_%%PKG_REPO_BRANCH_RELEASE%%_%%ARCH%%-core",
   mirror_type: "none",
   signature_type: "%%SIGNATURE_TYPE%%",
   fingerprints: "/usr/local/share/%%PRODUCT_NAME%%/keys/pkg",
@@ -9,7 +9,7 @@ FreeBSD: { enabled: no }
 }
 
 %%PRODUCT_NAME%%: {
-  url: "%%PKG_REPO_SERVER_RELEASE%%/%%PRODUCT_NAME%%_v2_9_0_%%ARCH%%-%%PRODUCT_NAME%%_v2_9_0",
+  url: "%%PKG_REPO_SERVER_RELEASE%%/%%PRODUCT_NAME%%_%%PKG_REPO_BRANCH_RELEASE%%_%%ARCH%%-%%PRODUCT_NAME%%_%%PKG_REPO_BRANCH_RELEASE%%",
   mirror_type: "none",
   signature_type: "%%SIGNATURE_TYPE%%",
   fingerprints: "/usr/local/share/%%PRODUCT_NAME%%/keys/pkg",

--- a/tools/templates/pkg_repos/Kontrol-repo.descr
+++ b/tools/templates/pkg_repos/Kontrol-repo.descr
@@ -1,1 +1,1 @@
-Current Stable Release (2.9.0-RELEASE)
+Current 2.7.2 (Default)


### PR DESCRIPTION
### Motivation
- Prevent a pkg upgrade on a FreeBSD 14 appliance from silently switching the default repo to the FreeBSD 16 (v2_9_0) packages which are incompatible with the running userland. 
- Make upgrade/previous targets explicit and independent so the default repository remains the safe v2_7_2 / FreeBSD 14 configuration. 
- Ensure the builder overlay used by `poudriere_bulk()` is deterministic and does not leave stale repo metadata from prior runs. 

### Description
- Added `PKG_REPO_BRANCH_UPGRADE="v2_9_0"` and exported the three branch variables in `tools/builder_defaults.sh`. 
- Extended `build.sh` validation to require `PKG_REPO_BRANCH_PREVIOUS` and `PKG_REPO_BRANCH_UPGRADE` for published builds. 
- In `tools/builder_common.sh`: pass `PKG_REPO_BRANCH_PREVIOUS` and `PKG_REPO_BRANCH_UPGRADE` into rendered templates, keep previous/upgrade branch names tied to release branches even when using staging servers, teach the copied port Makefile to render the previous placeholder when absent, and deterministically remove only generated repo metadata before copying the overlay so unrelated files (like `pkg-install` and signing keys) are preserved. 
- Updated `tools/conf/pfPorts/make.conf` to include `Kontrol-repo-upgrade` in `PFSENSE_PKG_SET_VERSION`. 
- Rewrote/added templates in `tools/templates/pkg_repos/` to produce three independent repo sets: `Kontrol-repo` (default/current v2_7_2, FreeBSD 14), `Kontrol-repo-previous` (rollback v2_7_0, FreeBSD 14), and `Kontrol-repo-upgrade` (explicit upgrade v2_9_0, FreeBSD 16). 

### Testing
- Static checks: `sh -n build.sh`, `sh -n tools/builder_defaults.sh`, and `sh -n tools/builder_common.sh` all succeeded with no syntax errors. 
- Lint/consistency: `git diff --check` produced no issues. 
- Template rendering: rendered all templates for `PRODUCT_NAME=Kontrol` and `ARCH=amd64` with `sed` substitutions and verified no `%%...%%` placeholders remained and the six expected URLs (`Kontrol_v2_7_2_amd64-*`, `Kontrol_v2_7_0_amd64-*`, `Kontrol_v2_9_0_amd64-*`) were present. 
- Overlay simulation: simulated the `poudriere_bulk()` overlay by deleting only generated repo metadata and copying `tools/templates/pkg_repos/*` into a clean port `files` directory and verified `.conf`, `.descr`, `.abi` and `.altabi` exist for current, previous and upgrade while preserving `pkg-install.in`. 
- Default marker: simulated the port default marker and confirmed only `/usr/local/share/Kontrol/pkg/repos/Kontrol-repo.conf.default` is created and not the upgrade `*.default`. 

Note: full `poudriere bulk` or `make package` runs were not executed because the environment lacks a configured poudriere/jail setup; no attempt was made to modify PHP or bootstrap pkg in this branch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a79b6e934832eba99c062b0c92353)