### PR TITLE
RELENG_2_9_0: align cross-major repository templates

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -278,7 +278,8 @@ if [ -n "${SNAPSHOTS}" -a -n "${UPLOAD}" ]; then
 		PKG_REPO_SERVER_RELEASE \
 		PKG_REPO_SERVER_STAGING \
 		PKG_REPO_BRANCH_DEVEL \
-		PKG_REPO_BRANCH_RELEASE"
+		PKG_REPO_BRANCH_RELEASE \
+		PKG_REPO_BRANCH_PREVIOUS"
 
 	for _var in ${_required}; do
 		eval "_value=\${$_var}"

--- a/tools/builder_common.sh
+++ b/tools/builder_common.sh
@@ -1134,11 +1134,13 @@ setup_pkg_repo() {
 	if [ -n "${_staging}" -a -n "${USE_PKG_REPO_STAGING}" ]; then
 		local _pkg_repo_server_devel=${PKG_REPO_SERVER_STAGING}
 		local _pkg_repo_branch_devel=${PKG_REPO_BRANCH_STAGING}
+		local _pkg_repo_branch_previous=${PKG_REPO_BRANCH_STAGING}
 		local _pkg_repo_server_release=${PKG_REPO_SERVER_STAGING}
 		local _pkg_repo_branch_release=${PKG_REPO_BRANCH_STAGING}
 	else
 		local _pkg_repo_server_devel=${PKG_REPO_SERVER_DEVEL}
 		local _pkg_repo_branch_devel=${PKG_REPO_BRANCH_DEVEL}
+		local _pkg_repo_branch_previous=${PKG_REPO_BRANCH_PREVIOUS}
 		local _pkg_repo_server_release=${PKG_REPO_SERVER_RELEASE}
 		local _pkg_repo_branch_release=${PKG_REPO_BRANCH_RELEASE}
 	fi
@@ -1153,6 +1155,7 @@ setup_pkg_repo() {
 		-e "s/%%MIRROR_TYPE%%/none/" \
 		-e '/mirror_type:/ s/"[^"]*"/"none"/' \
 		-e "s/%%PKG_REPO_BRANCH_DEVEL%%/${_pkg_repo_branch_devel}/g" \
+		-e "s/%%PKG_REPO_BRANCH_PREVIOUS%%/${_pkg_repo_branch_previous}/g" \
 		-e "s/%%PKG_REPO_BRANCH_RELEASE%%/${_pkg_repo_branch_release}/g" \
 		-e "s,%%PKG_REPO_SERVER_DEVEL%%,${_pkg_repo_server_devel},g" \
 		-e "s,%%PKG_REPO_SERVER_RELEASE%%,${_pkg_repo_server_release},g" \
@@ -2157,7 +2160,6 @@ poudriere_bulk() {
 	cat <<EOF >>/usr/local/etc/poudriere.d/${POUDRIERE_PORTS_NAME}-make.conf
 
 PKG_REPO_BRANCH_DEVEL=${PKG_REPO_BRANCH_DEVEL}
-PKG_REPO_BRANCH_NEXT=${PKG_REPO_BRANCH_NEXT}
 PKG_REPO_BRANCH_RELEASE=${PKG_REPO_BRANCH_RELEASE}
 PKG_REPO_BRANCH_PREVIOUS=${PKG_REPO_BRANCH_PREVIOUS}
 PKG_REPO_SERVER_DEVEL=${PKG_REPO_SERVER_DEVEL}
@@ -2203,10 +2205,20 @@ EOF
 			/usr/local/poudriere/ports/${POUDRIERE_PORTS_NAME}/sysutils/${PRODUCT_NAME}-repo/Makefile
 	fi
 
-	# Copy over pkg repo templates to pfSense-repo
-	mkdir -p /usr/local/poudriere/ports/${POUDRIERE_PORTS_NAME}/sysutils/${PRODUCT_NAME}-repo/files
-	cp -f ${PKG_REPO_BASE}/* \
-		/usr/local/poudriere/ports/${POUDRIERE_PORTS_NAME}/sysutils/${PRODUCT_NAME}-repo/files
+	# Replace repository templates in the renamed port.  Remove old repository
+	# definitions first so a stale upgrade/devel file cannot leak into a build.
+	local _repo_files=/usr/local/poudriere/ports/${POUDRIERE_PORTS_NAME}/sysutils/${PRODUCT_NAME}-repo/files
+	mkdir -p ${_repo_files}
+	find ${_repo_files} -type f \( \
+		-name "${PRODUCT_NAME}-repo*.conf" -o \
+		-name "${PRODUCT_NAME}-repo*.descr" -o \
+		-name "${PRODUCT_NAME}-repo*.abi" -o \
+		-name "${PRODUCT_NAME}-repo*.altabi" -o \
+		-name "${PRODUCT_NAME}-repo*.osversion" -o \
+		-name "${PRODUCT_NAME}-repo*.help" \) -delete
+	find ${PKG_REPO_BASE} -type f -mindepth 1 -maxdepth 1 | sort | while read _repo_template; do
+		cp -f ${_repo_template} ${_repo_files}/
+	done
 
 	for jail_arch in ${_archs}; do
 		jail_name=$(poudriere_jail_name ${jail_arch})

--- a/tools/builder_defaults.sh
+++ b/tools/builder_defaults.sh
@@ -53,15 +53,12 @@ if [ -f ${BUILD_CONF} ]; then
 	. ${BUILD_CONF}
 fi
 
-# Define pfSense versions
-PKG_REPO_BRANCH_DEVEL="v2_7_2"
-PKG_REPO_BRANCH_NEXT="v2_9_1"
-PKG_REPO_BRANCH_RELEASE="v2_9_0"
-PKG_REPO_BRANCH_PREVIOUS="v2_8_1"
-export PKG_REPO_BRANCH_DEVEL="v2_7_2"
-export PKG_REPO_BRANCH_NEXT="v2_9_1"
-export PKG_REPO_BRANCH_RELEASE="v2_9_0"
-export PKG_REPO_BRANCH_PREVIOUS="v2_8_1"
+# Define pfSense versions.  The devel name is retained for compatibility with
+# the repository name exposed by the GUI, but it is the legacy 2.7.2 rollback.
+export PKG_REPO_BRANCH_DEVEL=${PKG_REPO_BRANCH_DEVEL:-"v2_7_2"}
+export PKG_REPO_BRANCH_NEXT=${PKG_REPO_BRANCH_NEXT:-"v2_9_1"}
+export PKG_REPO_BRANCH_RELEASE=${PKG_REPO_BRANCH_RELEASE:-"v2_9_0"}
+export PKG_REPO_BRANCH_PREVIOUS=${PKG_REPO_BRANCH_PREVIOUS:-"v2_8_1"}
 
 # Make sure pkg will not be interactive
 export ASSUME_ALWAYS_YES=true

--- a/tools/templates/pkg_repos/Kontrol-repo-devel.conf
+++ b/tools/templates/pkg_repos/Kontrol-repo-devel.conf
@@ -1,7 +1,7 @@
 FreeBSD: { enabled: no }
 
 %%PRODUCT_NAME%%-core: {
-  url: "%%PKG_REPO_SERVER_RELEASE%%/%%PRODUCT_NAME%%_v2_7_2_%%ARCH%%-core",
+  url: "%%PKG_REPO_SERVER_RELEASE%%/%%PRODUCT_NAME%%_%%PKG_REPO_BRANCH_DEVEL%%_%%ARCH%%-core",
   mirror_type: "none",
   signature_type: "%%SIGNATURE_TYPE%%",
   fingerprints: "/usr/local/share/%%PRODUCT_NAME%%/keys/pkg",
@@ -9,7 +9,7 @@ FreeBSD: { enabled: no }
 }
 
 %%PRODUCT_NAME%%: {
-  url: "%%PKG_REPO_SERVER_RELEASE%%/%%PRODUCT_NAME%%_v2_7_2_%%ARCH%%-%%PRODUCT_NAME%%_v2_7_2",
+  url: "%%PKG_REPO_SERVER_RELEASE%%/%%PRODUCT_NAME%%_%%PKG_REPO_BRANCH_DEVEL%%_%%ARCH%%-%%PRODUCT_NAME%%_%%PKG_REPO_BRANCH_DEVEL%%",
   mirror_type: "none",
   signature_type: "%%SIGNATURE_TYPE%%",
   fingerprints: "/usr/local/share/%%PRODUCT_NAME%%/keys/pkg",

--- a/tools/templates/pkg_repos/Kontrol-repo-devel.descr
+++ b/tools/templates/pkg_repos/Kontrol-repo-devel.descr
@@ -1,1 +1,1 @@
-Deprecated snapshots (Backport 2.7.2 Deprecated)
+Legacy 2.7.2 rollback (devel filename retained for GUI compatibility)

--- a/tools/templates/pkg_repos/Kontrol-repo-previous.conf
+++ b/tools/templates/pkg_repos/Kontrol-repo-previous.conf
@@ -1,7 +1,7 @@
 FreeBSD: { enabled: no }
 
 %%PRODUCT_NAME%%-core: {
-  url: "%%PKG_REPO_SERVER_RELEASE%%/%%PRODUCT_NAME%%_v2_8_1_%%ARCH%%-core",
+  url: "%%PKG_REPO_SERVER_RELEASE%%/%%PRODUCT_NAME%%_%%PKG_REPO_BRANCH_PREVIOUS%%_%%ARCH%%-core",
   mirror_type: "none",
   signature_type: "%%SIGNATURE_TYPE%%",
   fingerprints: "/usr/local/share/%%PRODUCT_NAME%%/keys/pkg",
@@ -9,7 +9,7 @@ FreeBSD: { enabled: no }
 }
 
 %%PRODUCT_NAME%%: {
-  url: "%%PKG_REPO_SERVER_RELEASE%%/%%PRODUCT_NAME%%_v2_8_1_%%ARCH%%-%%PRODUCT_NAME%%_v2_8_1",
+  url: "%%PKG_REPO_SERVER_RELEASE%%/%%PRODUCT_NAME%%_%%PKG_REPO_BRANCH_PREVIOUS%%_%%ARCH%%-%%PRODUCT_NAME%%_%%PKG_REPO_BRANCH_PREVIOUS%%",
   mirror_type: "none",
   signature_type: "%%SIGNATURE_TYPE%%",
   fingerprints: "/usr/local/share/%%PRODUCT_NAME%%/keys/pkg",

--- a/tools/templates/pkg_repos/Kontrol-repo-previous.descr
+++ b/tools/templates/pkg_repos/Kontrol-repo-previous.descr
@@ -1,1 +1,1 @@
-Previous stable version (2.8.1 Previous)
+Previous 2.8.1 (rollback repository)

--- a/tools/templates/pkg_repos/Kontrol-repo.altabi
+++ b/tools/templates/pkg_repos/Kontrol-repo.altabi
@@ -1,1 +1,1 @@
-freeBSD:16:%%ARCH%%
+freebsd:16:%%ARCH%%

--- a/tools/templates/pkg_repos/Kontrol-repo.conf
+++ b/tools/templates/pkg_repos/Kontrol-repo.conf
@@ -1,7 +1,7 @@
 FreeBSD: { enabled: no }
 
 %%PRODUCT_NAME%%-core: {
-  url: "%%PKG_REPO_SERVER_RELEASE%%/%%PRODUCT_NAME%%_v2_9_0_%%ARCH%%-core",
+  url: "%%PKG_REPO_SERVER_RELEASE%%/%%PRODUCT_NAME%%_%%PKG_REPO_BRANCH_RELEASE%%_%%ARCH%%-core",
   mirror_type: "none",
   signature_type: "%%SIGNATURE_TYPE%%",
   fingerprints: "/usr/local/share/%%PRODUCT_NAME%%/keys/pkg",
@@ -9,7 +9,7 @@ FreeBSD: { enabled: no }
 }
 
 %%PRODUCT_NAME%%: {
-  url: "%%PKG_REPO_SERVER_RELEASE%%/%%PRODUCT_NAME%%_v2_9_0_%%ARCH%%-%%PRODUCT_NAME%%_v2_9_0",
+  url: "%%PKG_REPO_SERVER_RELEASE%%/%%PRODUCT_NAME%%_%%PKG_REPO_BRANCH_RELEASE%%_%%ARCH%%-%%PRODUCT_NAME%%_%%PKG_REPO_BRANCH_RELEASE%%",
   mirror_type: "none",
   signature_type: "%%SIGNATURE_TYPE%%",
   fingerprints: "/usr/local/share/%%PRODUCT_NAME%%/keys/pkg",

--- a/tools/templates/pkg_repos/Kontrol-repo.descr
+++ b/tools/templates/pkg_repos/Kontrol-repo.descr
@@ -1,1 +1,1 @@
-Current Stable Release (2.9.0-RELEASE)
+Current 2.9.0 (default repository)


### PR DESCRIPTION
### Motivation
- Tornar a produção de templates e as variáveis de build coerentes para o destino FreeBSD 16 (Kontrol 2.9.0) mantendo opções explícitas para o repositório anterior (2.8.1) e o retorno legado (2.7.2).
- Evitar duplicação de atribuições de branch e inconsistências de ALTABI/capitalização que podiam causar URLs incorretas ou templates herdados em overlay de `poudriere`.
- Preservar `Kontrol-repo` como o repositório default desta branch e manter o nome consumido pela GUI para compatibilidade sem mudar comportamento PHP.

### Description
- Centralizei e exportei as variáveis de branch em `tools/builder_defaults.sh` usando `PKG_REPO_BRANCH_RELEASE`, `PKG_REPO_BRANCH_PREVIOUS` e `PKG_REPO_BRANCH_DEVEL` (legacy), removendo atribuições duplicadas e documentando a finalidade do `DEVEL` como rollback para v2_7_2.
- Ajustei `build.sh` para exigir todas as branches publicadas relevantes (`RELEASE`, `PREVIOUS`, `DEVEL`) durante uploads de snapshots, sem exigir `NEXT` quando não aplicável.
- Em `tools/builder_common.sh` `setup_pkg_repo()` agora substitui `%%PKG_REPO_BRANCH_RELEASE%%`, `%%PKG_REPO_BRANCH_PREVIOUS%%` e `%%PKG_REPO_BRANCH_DEVEL%%` (com tratamento coerente de staging) e o fluxo de overlay tornou-se determinístico ao remover templates obsoletos antes de copiar o conjunto ordenado atual.
- Atualizei os templates em `tools/templates/pkg_repos`: `Kontrol-repo.conf`, `Kontrol-repo-previous.conf` e `Kontrol-repo-devel.conf` passam a usar as variáveis de branch; normalizei `altabi` para `freebsd` em minúsculas e clareei as descrições para "Current 2.9.0 (default)", "Previous 2.8.1 (rollback)" e "Legacy 2.7.2 rollback (devel filename retained for GUI compatibility)"; mantive `PFSENSE_PKG_SET_VERSION` contendo exatamente `Kontrol-repo`, `Kontrol-repo-previous` e `Kontrol-repo-devel` em `tools/conf/pfPorts/make.conf`.

### Testing
- Executei checagens de sintaxe com `sh -n build.sh`, `sh -n tools/builder_defaults.sh` e `sh -n tools/builder_common.sh`, todas concluíram com sucesso.
- Rodei `git diff --check` para garantir não haver problemas de whitespace/índice, sem erros detectados.
- Renderizei todos os templates com `PRODUCT_NAME=Kontrol` e `ARCH=amd64` e verifiquei que nenhum placeholder `%%...%%` permaneceu; verificação concluída com sucesso.
- Validei automaticamente as URLs finais e os ABI/ALTABI renderizados (Kontrol v2_9_0, v2_8_1, v2_7_2 para amd64) e confirmei que cada endpoint esperado aparece exatamente uma vez; todos os checks passaram.
- Simulei o overlay determinístico do diretório de port para `poudriere` com arquivos sujos (incluindo `Kontrol-repo-upgrade.conf`) e confirmei que arquivos obsoletos foram removidos enquanto arquivos auxiliares foram preservados.
- Comparei o template de upgrade de `RELENG_2_7_2` com o `Kontrol-repo` desta branch e confirmei que as URLs renderizadas coincidem exatamente.
- Nota: não executei `poudriere` real nem `make package` porque o ambiente não contém uma instalação FreeBSD/poudriere completa; esses passos são fora do escopo do ambiente de teste automatizado aqui.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a79e304f0832ebe6bd9684ff591c9)