### PR TITLE
Fix repository port Makefile command continuation

### DIFF
--- a/tools/builder_common.sh
+++ b/tools/builder_common.sh
@@ -2124,10 +2124,14 @@ EOF
 	# independent previous-branch placeholder. Teach the copied port to render it.
 	local _repo_makefile=/usr/local/poudriere/ports/${POUDRIERE_PORTS_NAME}/sysutils/${PRODUCT_NAME}-repo/Makefile
 	if ! grep -q '%%PKG_REPO_BRANCH_PREVIOUS%%' ${_repo_makefile}; then
-		sed -i '' \
-		    -e '/%%PKG_REPO_BRANCH_RELEASE%%/a\
-		-e "s,%%PKG_REPO_BRANCH_PREVIOUS%%,${PKG_REPO_BRANCH_PREVIOUS},g" \' \
-		    ${_repo_makefile}
+		awk '
+			{ print }
+			/^[[:space:]]*-e "s,%%PKG_REPO_BRANCH_RELEASE%%,/ {
+				print "\t\t-e \"s,%%PKG_REPO_BRANCH_PREVIOUS%%,${PKG_REPO_BRANCH_PREVIOUS},g\" \\"
+			}
+		' ${_repo_makefile} > ${_repo_makefile}.tmp || return 1
+		cat ${_repo_makefile}.tmp > ${_repo_makefile} || return 1
+		rm -f ${_repo_makefile}.tmp
 	fi
 
 	# Copy over pkg repo templates to pfSense-repo. Remove only generated repo


### PR DESCRIPTION
### Motivation

- The build failed when patching the legacy `${PRODUCT_NAME}-repo` Makefile because the previous in-place `sed -i ''` append attempted to operate on stdin and triggered `sed: -I or -i may not be used with stdin`, breaking the ports build step.
- The copied port needs an inserted replacement for `%%PKG_REPO_BRANCH_PREVIOUS%%` while preserving the trailing command-continuation backslash so the autogenerated `REINPLACE_CMD` invocation remains valid.

### Description

- Replace the fragile BSD `sed -i` append with an `awk`-based rewrite that prints the original file and inserts a properly quoted `-e "s,%%PKG_REPO_BRANCH_PREVIOUS%%,${PKG_REPO_BRANCH_PREVIOUS},g" \` line when the `-e "s,%%PKG_REPO_BRANCH_RELEASE%%,` continuation is encountered. 
- Preserve the trailing backslash on the inserted line so the continuation of the `REINPLACE_CMD` remains intact. 
- Perform the rewrite to a temporary file, atomically copy it back on success, and `rm -f` the temp file; return non-zero if the rewrite or copy fails to abort the build setup.
- Keep the change idempotent by only acting when `%%PKG_REPO_BRANCH_PREVIOUS%%` is not already present in the Makefile.

### Testing

- Ran `sh -n tools/builder_common.sh` to validate shell syntax and it succeeded. 
- Ran `git diff --check` to confirm no whitespace or diff errors and it reported clean. 
- Performed a fixture-based insertion test using the `RELENG_2_7_2` `pfSense-repo` Makefile and verified the `awk`-generated file contains a single insertion of the `%%PKG_REPO_BRANCH_PREVIOUS%%` replacement. 
- Verified the inserted line preserves the trailing `\` continuation and committed the change (`Fix previous repository sed injection`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a7f8e3084832ea5a3a86801356125)