### PR TITLE
Fix Kontrol service loading after 2.7.2 upgrades

### DIFF
--- a/src/usr/local/Kontrol/include/Services/Filesystem/Filesystems.php
+++ b/src/usr/local/Kontrol/include/Services/Filesystem/Filesystems.php
@@ -36,7 +36,7 @@ final class Filesystems {
 
 	private $provider = null;
 
-	public function __construct(AbstractProvider $provider = null) {
+	public function __construct(?AbstractProvider $provider = null) {
 		if (is_null($provider)
 		    || (!($provider instanceof AbstractProvider))) {
 			$provider = new SystemProvider();

--- a/src/usr/local/Kontrol/include/Services/Filesystem/Provider/AbstractProvider.php
+++ b/src/usr/local/Kontrol/include/Services/Filesystem/Provider/AbstractProvider.php
@@ -37,7 +37,7 @@ use Symfony\{
 abstract class AbstractProvider {
 	private $cacheAdapter = null;
 
-	public function __construct(AbstractAdapter $cacheAdapter = null) {
+	public function __construct(?AbstractAdapter $cacheAdapter = null) {
 		if (is_null($cacheAdapter) || (!($cacheAdapter instanceof AbstractAdapter))) {
 			require_once('globals.inc');
 

--- a/src/usr/local/Kontrol/include/autoload.inc.php
+++ b/src/usr/local/Kontrol/include/autoload.inc.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Kontrol base class autoloader.
+ *
+ * Keep first-party classes loadable independently of the generated Composer
+ * metadata.  Composer dependencies are packaged separately and may be
+ * replaced before Kontrol-base during an upgrade.
+ */
+
+spl_autoload_register(function ($class) {
+	$prefix = 'Kontrol\\';
+
+	if (strncmp($class, $prefix, strlen($prefix)) !== 0) {
+		return;
+	}
+
+	$file = __DIR__ . '/' . str_replace('\\', '/', substr($class, strlen($prefix))) . '.php';
+
+	if (is_file($file)) {
+		require_once($file);
+	}
+});

--- a/src/usr/local/www/guiconfig.inc
+++ b/src/usr/local/www/guiconfig.inc
@@ -67,6 +67,10 @@ include_once('config.lib.inc');
 /* parse the configuration and include all configuration functions */
 require_once("functions.inc");
 
+/* Load first-party Kontrol classes from Kontrol-base.  Do not rely on the
+ * separately packaged Composer autoload map for files owned by Kontrol-base. */
+require_once("/usr/local/Kontrol/include/autoload.inc.php");
+
 /* Include the autoloader for all the GUI display classes */
 require_once("classes/autoload.inc.php");
 

--- a/tests/KontrolAutoloadTest.php
+++ b/tests/KontrolAutoloadTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class KontrolAutoloadTest extends TestCase {
+	private const ROOT = __DIR__ . '/../src';
+
+	public function test_dashboard_bootstrap_registers_base_autoloader(): void {
+		$guiconfig = file_get_contents(self::ROOT . '/usr/local/www/guiconfig.inc');
+
+		$this->assertStringContainsString(
+			'require_once("/usr/local/Kontrol/include/autoload.inc.php");',
+			$guiconfig
+		);
+	}
+
+	public function test_upgrade_with_stale_composer_map_loads_filesystems(): void {
+		/* Simulate the 2.7.2 Composer loader left active during package upgrade:
+		 * it knows pfSense, but has no Kontrol PSR-4 entry. */
+		$legacyLoader = static function ($class): void {
+			if (str_starts_with($class, 'pfSense\\')) {
+				return;
+			}
+		};
+		spl_autoload_register($legacyLoader);
+		require_once(self::ROOT . '/usr/local/Kontrol/include/autoload.inc.php');
+
+		$this->assertTrue(class_exists(Kontrol\Services\Filesystem\Filesystems::class));
+		$this->assertTrue(class_exists(Kontrol\Services\Filesystem\Provider\SystemProvider::class));
+
+		spl_autoload_unregister($legacyLoader);
+	}
+
+	public function test_disks_widget_uses_packaged_filesystem_service(): void {
+		$widget = file_get_contents(self::ROOT . '/usr/local/www/widgets/include/disks.inc');
+
+		$this->assertStringContainsString('Kontrol\\Services\\Filesystem', $widget);
+		$this->assertStringContainsString('$filesystems = new Filesystems();', $widget);
+		$this->assertFileExists(self::ROOT . '/usr/local/Kontrol/include/Services/Filesystem/Filesystems.php');
+		$this->assertFileExists(self::ROOT . '/usr/local/Kontrol/include/Services/Filesystem/Filesystem.php');
+		$this->assertFileExists(self::ROOT . '/usr/local/Kontrol/include/Services/Filesystem/Provider/SystemProvider.php');
+	}
+
+	public function test_disks_widget_renders_with_dashboard_dependencies(): void {
+		if (!function_exists('gettext')) {
+			eval('function gettext($message) { return $message; }');
+		}
+
+		$widget = file_get_contents(self::ROOT . '/usr/local/www/widgets/include/disks.inc');
+		$widget = preg_replace('/^<\?php\s*/', '', $widget);
+		$widget = str_replace("require_once('vendor/autoload.php');", '', $widget);
+		/* Rendering helpers do not need to query the host running the test. */
+		$widget = str_replace('$filesystems = new Filesystems();', '$filesystems = null;', $widget);
+		eval($widget);
+
+		$html = disks_compose_progressbar(76)->toHtml();
+		$this->assertStringContainsString('progress-bar-danger', $html);
+		$this->assertStringContainsString('aria-valuenow="76"', $html);
+	}
+
+	public function test_composer_and_base_package_maps_agree(): void {
+		$composer = json_decode(file_get_contents(__DIR__ . '/../composer.json'), true, flags: JSON_THROW_ON_ERROR);
+
+		$this->assertSame('//usr/local/Kontrol/include/', $composer['autoload']['psr-4']['Kontrol\\']);
+		$this->assertFileExists(self::ROOT . '/usr/local/Kontrol/include/autoload.inc.php');
+	}
+
+	public function test_core_package_default_plist_includes_autoloader(): void {
+		$packager = file_get_contents(__DIR__ . '/../build/scripts/create_core_pkg.sh');
+
+		$this->assertStringContainsString('find ${froot} ${filter} -type f -or -type l', $packager);
+		$this->assertFileExists(self::ROOT . '/usr/local/Kontrol/include/autoload.inc.php');
+	}
+}


### PR DESCRIPTION
### Motivation

- The Disks widget instantiates `Kontrol\Services\Filesystem\Filesystems` but relied solely on generated Composer PSR-4 metadata shipped separately, which can be inconsistent during an upgrade (2.7.2 → 2.9.0) and caused the class-not-found fatal. 
- A clean install had coherent Composer metadata so it worked, while upgraded systems could keep a stale/incomplete generated map that lacked the `Kontrol\` PSR-4 prefix.

### Description

- Add a small first-party PSR-4 fallback autoloader at `src/usr/local/Kontrol/include/autoload.inc.php` that loads classes in the `Kontrol\` namespace directly from `Kontrol-base` source files. 
- Ensure the GUI bootstrap always registers that loader by requiring it from `src/usr/local/www/guiconfig.inc` before other widget includes. 
- Make constructors explicitly nullable for PHP 8.5 by changing `Filesystems::__construct` and `AbstractProvider::__construct` to use `?` nullable parameter types to remove implicit-null deprecation warnings. 
- Add regression tests in `tests/KontrolAutoloadTest.php` to cover dashboard bootstrap inclusion, loading with a simulated stale Composer loader, widget rendering helpers, Composer PSR-4 mapping, and presence of the new autoloader file. 

### Testing

- Ran `composer install --no-interaction --prefer-dist` to install deps and generate autoload files, which completed successfully. 
- Executed unit tests with `src/usr/local/Kontrol/include/vendor/bin/phpunit tests/KontrolAutoloadTest.php`, and the suite passed (`OK (6 tests, 14 assertions)`).
- Performed PHP syntax checks with `php -l` on modified files and ran `git diff --check`, all returned clean results.
- Verified repository state with `git status --short --branch` and committed the changes as a single fix commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6aae33658c832eb014e79d84c45e87)